### PR TITLE
Fixes in vice-setup-user and hoard

### DIFF
--- a/coda-src/scripts/vice-setup-user.in
+++ b/coda-src/scripts/vice-setup-user.in
@@ -66,7 +66,7 @@ until [ "x$userid" != x ]; do
         # test if $userid is an integer, a portable looking solution from
         # https://stackoverflow.com/questions/806906/how-do-i-test-if-a-variable-is-a-number-in-bash
         if [ "$userid" -eq "$userid" ] 2>/dev/null; then
-            ;
+            echo "nop" > /dev/null
         else
             echo "UID should be an integer value"
             userid=

--- a/coda-src/vtools/hoard.cc
+++ b/coda-src/vtools/hoard.cc
@@ -1274,7 +1274,7 @@ static void error(int fatal, const char *fmt ...) {
 
     /* Copy the message. */
     va_start(ap, fmt);
-    vsprintf(msg, fmt, ap);
+    vsnprintf(msg, 240, fmt, ap);
     va_end(ap);
 
     fprintf(stderr, "%s\n", msg);


### PR DESCRIPTION
I've compiled/installed coda and started playing around a bit. While doing so I stumbled upon two minor issues and patched them.

1) During server setup my bash complained about a semicolon on its own line and refused to continue. With the rephrased NOP, the script finished successfully
2) While playing around with 'hoard' I entered a malformed command line ("hoard add *.jpg 100"). The line became so long that it finally blew up the output buffer of 'parse_error'.

The two commits fix the described issues.