### PR TITLE
added -e to sh interpreter

### DIFF
--- a/coda-src/scripts/bldvldb.sh.in
+++ b/coda-src/scripts/bldvldb.sh.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # BLURB gpl
 # 
 #                            Coda File System

--- a/coda-src/scripts/coda-client-setup.in
+++ b/coda-src/scripts/coda-client-setup.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 #
 # Coda client installation script
 # Made for Linux coda-client rpm distribution 

--- a/coda-src/scripts/coda-server-logrotate
+++ b/coda-src/scripts/coda-server-logrotate
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 #
 # Simple logrotation for Coda server logfiles
 #

--- a/coda-src/scripts/codastart
+++ b/coda-src/scripts/codastart
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/sh -e
+
 if [ "`cat /vice/hostname`" = "`cat /vice/db/scm`" ]
 then
     updatesrv &

--- a/coda-src/scripts/createvol_rep.in
+++ b/coda-src/scripts/createvol_rep.in
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/sh -e
 # BLURB gpl
 # 
 #                            Coda File System

--- a/coda-src/scripts/purgevol_rep.in
+++ b/coda-src/scripts/purgevol_rep.in
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/sh -e
 # BLURB gpl
 # 
 #                            Coda File System

--- a/coda-src/scripts/startserver.in
+++ b/coda-src/scripts/startserver.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # BLURB gpl
 # 
 #                            Coda File System

--- a/coda-src/scripts/vice-killvolumes
+++ b/coda-src/scripts/vice-killvolumes
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/sh -e
 # BLURB gpl
 # 
 #                            Coda File System

--- a/coda-src/scripts/vice-setup-rvm.in
+++ b/coda-src/scripts/vice-setup-rvm.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # BLURB gpl
 #
 #			    Coda File System

--- a/coda-src/scripts/vice-setup-scm.in
+++ b/coda-src/scripts/vice-setup-scm.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # BLURB gpl
 # 
 #                            Coda File System

--- a/coda-src/scripts/vice-setup-srvdir.in
+++ b/coda-src/scripts/vice-setup-srvdir.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # BLURB gpl
 # 
 #                            Coda File System

--- a/coda-src/scripts/vice-setup-user.in
+++ b/coda-src/scripts/vice-setup-user.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # BLURB gpl
 # 
 #                            Coda File System

--- a/coda-src/scripts/vice-setup.in
+++ b/coda-src/scripts/vice-setup.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -e
 # BLURB gpl
 #
 #			Coda File System


### PR DESCRIPTION
because otherwise the script doesn't detect failure of delegate scripts (e.g. failure of vice-setup-user called in vice-setup causes weird result/feedback)