### PR TITLE
Fixes in 9P recv_walk() for non-existing paths.

### DIFF
--- a/coda-src/venus/9pfs.cc
+++ b/coda-src/venus/9pfs.cc
@@ -707,6 +707,7 @@ int plan9server::recv_walk(unsigned char *buf, size_t len, uint16_t tag)
 
         DEBUG("9pfs: Twalk[%x] discarding after error wname[%u] = '%s'\n",
               tag, i, wname);
+        ::free(wname);
     }
 
     /* report lookup errors only for the first path element 

--- a/coda-src/venus/9pfs.cc
+++ b/coda-src/venus/9pfs.cc
@@ -690,6 +690,8 @@ int plan9server::recv_walk(unsigned char *buf, size_t len, uint16_t tag)
 
             if (conn->u.u_error) {
                 ::free(wname);
+                /* avoid unpacking one string too much when discarding later */
+                i++;
                 break;
             }
             current = child;
@@ -707,8 +709,14 @@ int plan9server::recv_walk(unsigned char *buf, size_t len, uint16_t tag)
               tag, i, wname);
     }
 
-    /* report lookup errors only for the first path element */
-    if (i == 0 && conn->u.u_error) {
+    /* report lookup errors only for the first path element 
+       if (i == 0 && conn->u.u_error) { */
+    /* I don't understand the original intention here. 
+       In the case where nwname == 0, we would be checking 
+       u.u_error without having performed the lookup operation, 
+       so actually picking up the error from a prior operation. 
+       (AS) */
+    if (nwname > 0 && conn->u.u_error) {
         const char *errstr = VenusRetStr(conn->u.u_error);
         return send_error(tag, errstr);
     }
@@ -1156,6 +1164,7 @@ int plan9server::recv_wstat(unsigned char *buf, size_t len, uint16_t tag)
     uint32_t fid;
     uint16_t statlen;
     struct plan9_stat stat;
+    int rc;
 
     if (unpack_le32(&buf, &len, &fid) ||
         unpack_le16(&buf, &len, &statlen) ||
@@ -1168,7 +1177,7 @@ int plan9server::recv_wstat(unsigned char *buf, size_t len, uint16_t tag)
     ::free(stat.gid);
     ::free(stat.uid);
     ::free(stat.name);
-#if 0
+
     /* send_Rwstat */
     DEBUG("9pfs: Rwstat[%x]\n", tag);
 
@@ -1176,8 +1185,6 @@ int plan9server::recv_wstat(unsigned char *buf, size_t len, uint16_t tag)
     rc = pack_header(&buf, &len, Rwstat, tag);
     assert(rc == 0);
     return send_response(buffer, max_msize - len);
-#endif
-    return send_error(tag, "Operation not supported");
 }
 
 


### PR DESCRIPTION
* Fixes off-by-1 error causing extra path unpacking/discarding after a lookup error.
* Fixes if() condition incorrectly returning error when walking with no path arguments.
* Re-enables recv_wstat(): modifying existing files is now working