### PR TITLE
Plan 9 wstat implemented

### DIFF
--- a/coda-src/venus/9pfs.cc
+++ b/coda-src/venus/9pfs.cc
@@ -1510,7 +1510,8 @@ int plan9server::plan9_stat(struct venus_cnode *cnode, struct attachment *root,
         return -1;
 
     //stat->mode |= (attr.va_mode & (S_IRWXU|S_IRWXG|S_IRWXO));
-    stat->mode |= (stat->qid.type == P9_QTDIR) ? 0777 : 0666;
+    stat->mode |= (stat->qid.type == P9_QTDIR || attr.va_mode & S_IXUSR) ?
+                  0777 : 0666;
     stat->atime = attr.va_atime.tv_sec;
     stat->mtime = attr.va_mtime.tv_sec;
     stat->length = (stat->qid.type == P9_QTDIR) ? 0 : attr.va_size;

--- a/coda-src/venus/9pfs.h
+++ b/coda-src/venus/9pfs.h
@@ -197,6 +197,10 @@ class plan9server {
                    struct plan9_stat *stat, const char *name = NULL);
     ssize_t plan9_read(struct fidmap *fm, unsigned char *buf,
                        size_t count, size_t offset);
+
+    int cnode_name(struct venus_cnode *cnode, const char *name);
+    int cnode_parent(struct venus_cnode *cnode, struct venus_cnode *parent);
+
 public:
     plan9server(mariner *conn);
     ~plan9server();

--- a/coda-src/venus/9pfs.h
+++ b/coda-src/venus/9pfs.h
@@ -95,19 +95,24 @@ enum plan9_message_types {
 /* size of 9pfs message header */
 #define P9_MIN_MSGSIZE (sizeof(uint32_t)+sizeof(uint8_t)+sizeof(uint16_t))
 
-#define P9_QTDIR     0x80
+/* File types for use in Plan9 qid
+ * and as higher 8 bits of mode field in Plan9 stat
+ */
+#define P9_QTDIR     0x80  /* directory */
 #define P9_QTAUTH    0x08
 #define P9_QTSYMLINK 0x02
-#define P9_QTFILE    0x00
+#define P9_QTFILE    0x00  /* regular file */
+#define P9_DMAPPEND  0x40  /* append-only file */
+#define P9_DMEXCL    0x20  /* exclusive use file */
+#define P9_DMTMP     0x04  /* temporary file */
 
+/* Plan9 open/create flags */
 #define P9_OREAD   0x00
 #define P9_OWRITE  0x01
 #define P9_ORDWR   0x02
 #define P9_OEXEC   0x03
 #define P9_OTRUNC  0x10
 #define P9_ORCLOSE 0x40
-
-#define P9_DMDIR   0x80000000  /* permission bit indicating a directory */ 
 
 
 struct plan9_qid {
@@ -130,6 +135,22 @@ struct plan9_stat {
     char *gid;
     char *muid;
 };
+
+/* Plan9 stat "don't touch" values for writing stat */
+#define P9_DONT_TOUCH_TYPE      ((uint16_t)(-1))
+#define P9_DONT_TOUCH_DEV       ((uint32_t)(-1))
+#define P9_DONT_TOUCH_QID_TYPE  ((uint8_t)(-1))
+#define P9_DONT_TOUCH_QID_VERS  ((uint32_t)(-1))
+#define P9_DONT_TOUCH_QID_PATH  ((uint64_t)(-1))
+#define P9_DONT_TOUCH_MODE      ((uint32_t)(-1))
+#define P9_DONT_TOUCH_ATIME     ((uint32_t)(-1))
+#define P9_DONT_TOUCH_MTIME     ((uint32_t)(-1))
+#define P9_DONT_TOUCH_LENGTH    ((uint64_t)(-1))
+#define P9_DONT_TOUCH_NAME      ""
+#define P9_DONT_TOUCH_UID       ""
+#define P9_DONT_TOUCH_GID       ""
+#define P9_DONT_TOUCH_MUID      ""
+
 
 #ifdef __cplusplus
 }

--- a/coda-src/venus/9pfs.h
+++ b/coda-src/venus/9pfs.h
@@ -189,8 +189,8 @@ class plan9server {
     int recv_wstat(unsigned char *buf, size_t len, uint16_t tag);
 
     struct fidmap *find_fid(uint32_t fid);
-    struct fidmap *add_fid(uint32_t fid, struct fidmap * parent_fm,
-                          struct venus_cnode *cnode, struct attachment *root);
+    struct fidmap *add_fid(uint32_t fid, struct venus_cnode *cnode,
+                           struct attachment *root);
     int del_fid(uint32_t fid);
 
     int plan9_stat(struct venus_cnode *cnode, struct attachment *root,

--- a/coda-src/venus/9pfs.h
+++ b/coda-src/venus/9pfs.h
@@ -198,8 +198,8 @@ class plan9server {
     ssize_t plan9_read(struct fidmap *fm, unsigned char *buf,
                        size_t count, size_t offset);
 
-    int cnode_name(struct venus_cnode *cnode, const char *name);
-    int cnode_parent(struct venus_cnode *cnode, struct venus_cnode *parent);
+    int cnode_getname(struct venus_cnode *cnode, char *name);
+    int cnode_getparent(struct venus_cnode *cnode, struct venus_cnode *parent);
 
 public:
     plan9server(mariner *conn);


### PR DESCRIPTION
All file operations working, but need more testing. 
Returned to lighter fidmap design without parent (get it from fsobj instead). 
Factored out cnode_getname() and cnode_getparent() from remove, stat and wstat. 
Stat shows executable bit for executable files.  