### PR TITLE
Add Environmental Variable Parsing for Vice

### DIFF
--- a/lib-src/base/Makefile.am
+++ b/lib-src/base/Makefile.am
@@ -8,7 +8,7 @@ libbase_la_SOURCES = base64.h base64.c coda_assert.h coda_assert.c \
     coda_getaddrinfo.h coda_getaddrinfo.c coda_getservbyname.h \
     coda_getservbyname.c coda_malloc.c copyfile.h copyfile.c deprecations.h \
     dllist.h dllist.c getpeereid.h getpeereid.c \
-    parse_realms.h parse_realms.c urlquote.h urlquote.c
+    parse_realms.h parse_realms.c urlquote.h urlquote.c codaenv.c codaenv.h
 
 if HAVE_READLINE
 libbase_la_SOURCES += parser.h parser.c
@@ -21,4 +21,3 @@ endif
 AM_CPPFLAGS = $(RPC2_CFLAGS)
 
 EXTRA_DIST = README.parser
-

--- a/lib-src/base/codaenv.c
+++ b/lib-src/base/codaenv.c
@@ -1,0 +1,64 @@
+/* BLURB lgpl
+
+                           Coda File System
+                              Release 6
+
+          Copyright (c) 1987-2016 Carnegie Mellon University
+                  Additional copyrights listed below
+
+This  code  is  distributed "AS IS" without warranty of any kind under
+the  terms of the  GNU  Library General Public Licence  Version 2,  as
+shown in the file LICENSE. The technical and financial contributors to
+Coda are listed in the file CREDITS.
+
+                        Additional copyrights
+                           none currently
+
+#*/
+
+#include <sys/param.h>
+#include <stdio.h>
+#include "coda_string.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "codaenv.h"
+
+
+char * codaenv_find(const char * var_name) {
+    char env_var[256];
+    char * val = NULL;
+
+    snprintf(env_var, sizeof(env_var), "CODA_%s\0", var_name);
+
+    val = getenv(env_var);
+
+    if (!val) {
+        return NULL;
+    }
+
+    return strdup(val);
+}
+
+int codaenv_int(const char * var_name, const int prev_val)
+{
+    char * val = codaenv_find(var_name);
+
+    if (!val) {
+        return prev_val;
+    }
+
+    return atoi(val);
+}
+
+
+const char * codaenv_str(const char * var_name, const char * prev_val)
+{
+    char * val = codaenv_find(var_name);
+
+    if (!val) {
+        return prev_val;
+    }
+
+    return val;
+}

--- a/lib-src/base/codaenv.h
+++ b/lib-src/base/codaenv.h
@@ -1,0 +1,37 @@
+/* BLURB lgpl
+
+                           Coda File System
+                              Release 6
+
+          Copyright (c) 1987-2003 Carnegie Mellon University
+                  Additional copyrights listed below
+
+This  code  is  distributed "AS IS" without warranty of any kind under
+the  terms of the  GNU  Library General Public Licence  Version 2,  as
+shown in the file LICENSE. The technical and financial contributors to
+Coda are listed in the file CREDITS.
+
+                        Additional copyrights
+                           none currently
+
+#*/
+
+#ifndef _CODAENV_H_
+#define _CODAENV_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+char * codaenv_find(const char * var_name);
+
+int codaenv_int(const char *var_name, const int prev_val);
+
+const char *codaenv_str(const char *var_name,
+                        const char *prev_val);
+    
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _CODAENV_H_ */


### PR DESCRIPTION
* Most configuration parameters are now also parsed from the env variables. Note that for avoiding conflicting names the env var names are formatted as follows;

  * `CODA_%s`. Where`%s` is the name of the configuration parameter in `/etc/coda/server.conf`.

* The configuration parameters are now parsed slightly different. The value is obtained with the presendence below (highest presendence overrides values of lower presendence). Meaning that the value given by an Environmental variable will override any command line argument or configuration value in `/etc/coda/server.conf`.
  
  1. Environment variable formatted as explained above
  2. Command line argument
  3. Confinguration value in `/etc/coda/server.conf`

* This changes are part of the changes needed to dockerdize the coda-server (aka. vice)