### PR TITLE
Change Venus Cache Sizing paradigm

### DIFF
--- a/coda-src/venus/fso.h
+++ b/coda-src/venus/fso.h
@@ -135,11 +135,11 @@ class fsdb {
     int damnitagain;
 
     /* Size parameters. */
-    int MaxFiles;
+    uint64_t MaxFiles;
     /* "files" is kept as count member of htab */
     int FreeFileMargin;
-    /*T*/int MaxBlocks;
-    /*T*/int blocks;
+    /*T*/uint64_t MaxBlocks;
+    /*T*/uint64_t blocks;
     /*T*/int FreeBlockMargin;
 
     /* Priority parameters. */

--- a/coda-src/venus/venus.cc
+++ b/coda-src/venus/venus.cc
@@ -91,7 +91,7 @@ const char *kernDevice;
 const char *realmtab;
 const char *CacheDir;
 const char *CachePrefix;
-int   CacheBlocks;
+uint64_t    CacheBlocks;
 uid_t PrimaryUser = UNSET_PRIMARYUSER;
 const char *SpoolDir;
 const char *CheckpointFormat;
@@ -153,6 +153,16 @@ struct in_addr venus_relay_addr = { INADDR_LOOPBACK };
 
 /* socket connecting us back to our parent */
 int parent_fd = -1;
+
+/* Bytes units convertion */
+static const char * KBYTES_UNIT[] = { "KB", "kb", "Kb", "kB" };
+static const int KBYTE_UNIT_SCALE = 1;
+static const char * MBYTES_UNIT[] = { "MB", "mb", "Mb", "mB" };
+static const int MBYTE_UNIT_SCALE = 1024 * KBYTE_UNIT_SCALE;
+static const char * GBYTES_UNIT[] = { "GB", "gb", "Gb", "gB" };
+static const int GBYTE_UNIT_SCALE = 1024 * MBYTE_UNIT_SCALE;
+static const char * TBYTES_UNIT[] = { "TB", "tb", "Tb", "tB" };
+static const int TBYTE_UNIT_SCALE = 1024 * GBYTE_UNIT_SCALE;
 
 
 /* Some helpers to add fd/callbacks to the inner select loop */
@@ -234,6 +244,50 @@ void MUX_add_callback(int fd, void (*cb)(int fd, void *udata), void *udata)
 
     cbe->next = _MUX_CBEs;
     _MUX_CBEs = cbe;
+}
+
+/*
+ * Parse cachesize value and converts into amount of 1K-Blocks 
+ */
+static uint64_t ParseCacheSize(const char * CacheSize)
+{
+    const char * units = NULL;
+    int scale_factor = 1;
+    char CacheSizeWOUnits[256];
+    size_t cachesize_len = 0;
+    uint64_t cachesize = 0;
+
+    /* Locate the units and determine the scale factor */
+    for (int i = 0; i < 4; i++) {
+        if (units = strstr(CacheSize, MBYTES_UNIT[i])) {
+            scale_factor = MBYTE_UNIT_SCALE;
+            break;
+        }
+
+        if (units = strstr(CacheSize, GBYTES_UNIT[i])) {
+            scale_factor = GBYTE_UNIT_SCALE;
+            break;
+        }
+
+        if (units = strstr(CacheSize, TBYTES_UNIT[i])) {
+            scale_factor = TBYTE_UNIT_SCALE;
+            break;
+        }
+    }
+
+    /* Strip the units from string */
+    if (units) {
+        cachesize_len = (size_t)((units - CacheSize) / sizeof(char));
+        strncpy(CacheSizeWOUnits, CacheSize, cachesize_len);
+        CacheSizeWOUnits[cachesize_len] = 0;  // Make it null-terminated
+    } else {
+        snprintf(CacheSizeWOUnits, sizeof(CacheSizeWOUnits), CacheSize);
+    }
+
+    /* Scale the value */
+    cachesize = scale_factor * atof(CacheSizeWOUnits);
+
+    return cachesize;
 }
 
 
@@ -382,7 +436,7 @@ static void Usage(char *argv0)
 " -rpcdebug <n>\t\t\trpc2 debug level\n"
 " -lwpdebug <n>\t\t\tlwp debug level\n"
 " -cf <n>\t\t\t# of cache files\n"
-" -c <n>\t\t\t\tcache size in KB\n"
+" -c <n>[KB|MB|GB|TB]\t\t\t\tcache size in the given units (e.g. 10MB)\n"
 " -mles <n>\t\t\t# of CML entries\n"
 " -hdbes <n>\t\t\t# of hoard database entries\n"
 " -rdstrace\t\t\tenable RDS heap tracing\n"
@@ -458,7 +512,7 @@ static void ParseCmdline(int argc, char **argv)
 	    else if (STREQ(argv[i], "-cf"))   /* number of cache files */
 		i++, CacheFiles = atoi(argv[i]);
 	    else if (STREQ(argv[i], "-c"))    /* cache block size */
-		i++, CacheBlocks = atoi(argv[i]);  
+		i++, CacheBlocks = ParseCacheSize(argv[i]);  
 	    else if (STREQ(argv[i], "-hdbes")) /* hoard DB entries */
 		i++, HDBEs = atoi(argv[i]);
 	    else if (STREQ(argv[i], "-d"))     /* debugging */
@@ -591,11 +645,28 @@ static void ParseCmdline(int argc, char **argv)
 static void DefaultCmdlineParms()
 {
     int DontUseRVM = 0;
+    const char *CacheSize;
 
     /* Load the "venus.conf" configuration file */
     codaconf_init("venus.conf");
 
-    CODACONF_INT(CacheBlocks,	    "cacheblocks",   40000);
+    CODACONF_INT(CacheFiles, "cachefiles", 85);
+    if (CacheFiles < MIN_CF) {
+        eprint("Cannot start: minimum number of cache files is %d", MIN_CF);
+        exit(EXIT_UNCONFIGURED);
+    }
+
+    if (!CacheBlocks) {
+        CODACONF_STR(CacheSize, "cachesize", MIN_CS);
+        CacheBlocks = ParseCacheSize(CacheSize);
+    }
+
+    /* In case of user missconfiguration */
+    if (CacheBlocks < MIN_CB) {
+        eprint("Cannot start: minimum cache size is %s", "2MB");
+        exit(EXIT_UNCONFIGURED);
+    }
+    
     CODACONF_STR(CacheDir,	    "cachedir",      DFLT_CD);
     CODACONF_STR(SpoolDir,	    "checkpointdir", "/usr/coda/spool");
     CODACONF_STR(VenusLogFile,	    "logfile",	     DFLT_LOGFILE);
@@ -630,16 +701,6 @@ static void DefaultCmdlineParms()
     {
 	if (DontUseRVM)
 	    RvmType = VM;
-    }
-
-    CODACONF_INT(CacheFiles, "cachefiles", 0);
-    {
-	if (!CacheFiles) CacheFiles = CacheBlocks / BLOCKS_PER_FILE;
-
-	if (CacheFiles < MIN_CF) {
-	    eprint("Cannot start: minimum number of cache files is %d", MIN_CF);
-	    exit(EXIT_UNCONFIGURED);
-	}
     }
 
     CODACONF_INT(MLEs, "cml_entries", 0);
@@ -804,4 +865,3 @@ static void SetRlimits() {
     }
 #endif
 }
-

--- a/coda-src/venus/venus.cc
+++ b/coda-src/venus/venus.cc
@@ -156,13 +156,13 @@ struct in_addr venus_relay_addr = { INADDR_LOOPBACK };
 int parent_fd = -1;
 
 /* Bytes units convertion */
-static const char * KBYTES_UNIT[] = { "KB", "kb", "Kb", "kB" };
+static const char * KBYTES_UNIT[] = { "KB", "kb", "Kb", "kB", "K", "k"};
 static const int KBYTE_UNIT_SCALE = 1;
-static const char * MBYTES_UNIT[] = { "MB", "mb", "Mb", "mB" };
+static const char * MBYTES_UNIT[] = { "MB", "mb", "Mb", "mB", "M", "m"};
 static const int MBYTE_UNIT_SCALE = 1024 * KBYTE_UNIT_SCALE;
-static const char * GBYTES_UNIT[] = { "GB", "gb", "Gb", "gB" };
+static const char * GBYTES_UNIT[] = { "GB", "gb", "Gb", "gB", "G", "g"};
 static const int GBYTE_UNIT_SCALE = 1024 * MBYTE_UNIT_SCALE;
-static const char * TBYTES_UNIT[] = { "TB", "tb", "Tb", "tB" };
+static const char * TBYTES_UNIT[] = { "TB", "tb", "Tb", "tB", "T", "t"};
 static const int TBYTE_UNIT_SCALE = 1024 * GBYTE_UNIT_SCALE;
 
 
@@ -259,7 +259,12 @@ static uint64_t ParseCacheSize(const char * CacheSize)
     uint64_t cachesize = 0;
 
     /* Locate the units and determine the scale factor */
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 6; i++) {
+        if (units = strstr(CacheSize, KBYTES_UNIT[i])) {
+            scale_factor = KBYTE_UNIT_SCALE;
+            break;
+        }
+        
         if (units = strstr(CacheSize, MBYTES_UNIT[i])) {
             scale_factor = MBYTE_UNIT_SCALE;
             break;

--- a/coda-src/venus/venus.cc
+++ b/coda-src/venus/venus.cc
@@ -248,9 +248,9 @@ void MUX_add_callback(int fd, void (*cb)(int fd, void *udata), void *udata)
 }
 
 /*
- * Parse cachesize value and converts into amount of 1K-Blocks 
+ * Parse size value and converts into amount of 1K-Blocks 
  */
-static uint64_t ParseCacheSize(const char * CacheSize)
+static uint64_t ParseSizeWithUnits(const char * CacheSize)
 {
     const char * units = NULL;
     int scale_factor = 1;
@@ -518,7 +518,7 @@ static void ParseCmdline(int argc, char **argv)
 	    else if (STREQ(argv[i], "-cf"))   /* number of cache files */
 		i++, CacheFiles = atoi(argv[i]);
 	    else if (STREQ(argv[i], "-c"))    /* cache block size */
-		i++, CacheBlocks = ParseCacheSize(argv[i]);  
+		i++, CacheBlocks = ParseSizeWithUnits(argv[i]);  
 	    else if (STREQ(argv[i], "-hdbes")) /* hoard DB entries */
 		i++, HDBEs = atoi(argv[i]);
 	    else if (STREQ(argv[i], "-d"))     /* debugging */
@@ -677,7 +677,7 @@ static void DefaultCmdlineParms()
 
     if (!CacheBlocks) {
         CODACONF_STR(CacheSize, "cachesize", MIN_CS);
-        CacheBlocks = ParseCacheSize(CacheSize);
+        CacheBlocks = ParseSizeWithUnits(CacheSize);
     }
 
     /* In case of user missconfiguration */

--- a/coda-src/venus/venus.conf.ex
+++ b/coda-src/venus/venus.conf.ex
@@ -23,12 +23,13 @@
 #realmtab=/etc/coda/realms
 
 #
-# What should the size of the local cache be in 1k blocks. If this is
-# not specified or `0' the default value of 40000 (40MB) is chosen.
-# Minimum value is 4096.
+# What should the size of the local cache be. If this is not specified or 
+# `0' the default value of 2048 or 2MB is chosen. Supported units are KB, 
+# MB, GB, and TB.
+# Minimum value is 2048 or 2MB.
 #
-#cacheblocks=40000
-cacheblocks=100000
+#cachesize=40MB
+cachesize=100MB
 
 #
 # How many files should the venus cache hold. If this is not specified

--- a/coda-src/venus/venus.private.h
+++ b/coda-src/venus/venus.private.h
@@ -96,6 +96,7 @@ extern "C" {
 
 #define DFLT_LOGFILE "/usr/coda/etc/venus.log"	/* venus log file */
 #define DFLT_ERRLOG  "/usr/coda/etc/console"	/* venus error log */
+#define MIN_CS "2MB\0"
 
 /* rule of thumb */
 const int BLOCKS_PER_FILE = 24;
@@ -340,7 +341,7 @@ extern const char *kernDevice;
 extern const char *realmtab;
 extern const char *CacheDir;
 extern const char *CachePrefix;
-extern int CacheBlocks;
+extern uint64_t CacheBlocks;
 extern const char *SpoolDir;
 extern uid_t PrimaryUser;
 extern const char *VenusPidFile;


### PR DESCRIPTION
Includes;
* Replacing `cacheblocks` configuration parameter with `cachesize`, but maintaining backward compatibility.
* Logarithmic formula for calculating the number of cache files out of the `cachesize`. (Moving away from the concept of average cache file size of 24KB)