### PR TITLE
Add VASTRO support without partial discarting

### DIFF
--- a/coda-src/venus/fso.h
+++ b/coda-src/venus/fso.h
@@ -637,6 +637,7 @@ class fsobj {
     int  MakeShadow();
     void RemoveShadow();
     void CacheReport(int, int);
+    CacheChunkList * GetHoles(uint64_t start, int64_t len);
 
     void print() { print(stdout); }
     void print(FILE *fp) { fflush(fp); print(fileno(fp)); }

--- a/coda-src/venus/fso.h
+++ b/coda-src/venus/fso.h
@@ -138,6 +138,8 @@ class fsdb {
 
     /* Size parameters. */
     unsigned int MaxFiles;
+    uint64_t WholeFileCachingMaxSize;
+
     /* "files" is kept as count member of htab */
     int FreeFileMargin;
     /*T*/unsigned int MaxBlocks;
@@ -420,7 +422,6 @@ class fsobj {
 
     // for asr invocation
     /*T*/long lastresolved;			// time when object was last resolved
-    
 
     /* Constructors, destructors. */
     void *operator new(size_t, fso_alloc_t, int); /* for allocation from freelist */

--- a/coda-src/venus/fso.h
+++ b/coda-src/venus/fso.h
@@ -142,8 +142,8 @@ class fsdb {
 
     /* "files" is kept as count member of htab */
     int FreeFileMargin;
-    /*T*/unsigned int MaxBlocks;
-    /*T*/unsigned int blocks;
+    /*T*/uint64_t MaxBlocks;
+    /*T*/uint64_t blocks;
     /*T*/int FreeBlockMargin;
 
     /* Priority parameters. */

--- a/coda-src/venus/fso0.cc
+++ b/coda-src/venus/fso0.cc
@@ -737,23 +737,17 @@ RestartFind:
 	       a result of the inconsistent object manipulation above. */
 	    if (getdata && FETCHABLE(f) && !f->IsFake() && !HAVEALLDATA(f))
 	    {
-		int nblocks = BLOCKS(f);
 
 		/* If we haven't got any data yet, allocate enough for the
 		 * whole file. When we have a partial file, we should
 		 * already have reserved enough blocks. */
-		if (f->IsFile() && !HAVEDATA(f)) {
-		  code = AllocBlocks(vp->u.u_priority, nblocks);
+		if (f->IsFile() && !HAVEDATA(f) && !ISVASTRO(f)) {
+		  code = AllocBlocks(vp->u.u_priority, BLOCKS(f));
 		  if (code != 0) {
 			Put(&f);
 			return(code);
 		  }
 		}
-		
-		/* compensate # blocks for the amount we already have.
-		 * (only used for vmon statistical stuff later on, but
-		 * the fetch will modify f->cf.ValidData) */
-		nblocks -= NBLOCKS(f->cf.ValidData());
 		
 		code = 0;
 		/* first try the LookAside cache */

--- a/coda-src/venus/fso0.cc
+++ b/coda-src/venus/fso0.cc
@@ -1400,11 +1400,14 @@ void fsdb::ReclaimBlocks(int priority, int nblocks) {
 	if (priority <= f->priority) break;
 
 	/* No point in reclaiming entries without data! */
-	int ufs_blocks = NBLOCKS(f->cf.Length());
+	int ufs_blocks = NBLOCKS(f->cf.ValidData());
 	if (ufs_blocks == 0) continue;
 
-	/* Can't reclaim if busy. */
-	if (BUSY(f) || f->IsLocalObj()) continue;
+	/* Can't reclaim if it's local */
+    if (f->IsLocalObj()) continue;
+    
+    /* Can't reclaim if busy. */
+	if (BUSY(f) && !ISVASTRO(f)) continue;
 
 	/* Reclaim data.  Return if we've got enough. */
 	MarinerLog("cache::Replace [data] %s [%d, %d]\n",

--- a/coda-src/venus/fso0.cc
+++ b/coda-src/venus/fso0.cc
@@ -64,6 +64,7 @@ extern "C" {
 #include "worker.h"
 
 int CacheFiles = 0;
+uint64_t WholeFileMaxSize = 0;
 int FSO_SWT = UNSET_SWT;
 int FSO_MWT = UNSET_MWT;
 int FSO_SSF = UNSET_SSF;
@@ -509,7 +510,8 @@ int fsdb::Get(fsobj **f_addr, VenusFid *key, uid_t uid, int rights,
      *  NotifyUserOfProgramAccess(uid, vp->u.u_pid, vp->u.u_pgid, key); */
 
     /* Volume state synchronization. */
-    /* If a thread is already "in" one volume, we must switch contexts before entering another. */
+    /* If a thread is already "in" one volume, we must switch contexts 
+     * before entering another. */
     if (vp->u.u_vol &&
 	!(vp->u.u_vol->GetRealmId() == key->Realm &&
 	  vp->u.u_vol->GetVolumeId() == key->Volume))
@@ -726,6 +728,8 @@ RestartFind:
 		    return(code);
 		}
 	   }
+       
+       f->UpdateVastroFlag(uid);
 
 	    /* If we want data and we don't have any then fetch new stuff. */
 	    /* we have to re-check FETCHABLE because it may have changed as

--- a/coda-src/venus/fso1.cc
+++ b/coda-src/venus/fso1.cc
@@ -1514,8 +1514,9 @@ void fsobj::EnableReplacement() {
 
     /* Are ALL conditions for replaceability met? */
     if (DYING(this) || !HAVESTATUS(this) || DIRTY(this) || IsLocalObj() ||
-	 READING(this) || WRITING(this) || (children && children->count() > 0) ||
-	 IsMtPt() || (IsSymLink() && hdb_bindings && hdb_bindings->count() > 0))
+	 (READING(this) && !ISVASTRO(this))|| WRITING(this) || 
+     (children && children->count() > 0) ||	 IsMtPt() || 
+     (IsSymLink() && hdb_bindings && hdb_bindings->count() > 0))
 	return;
 
     /* Sanity check. */

--- a/coda-src/venus/fso1.cc
+++ b/coda-src/venus/fso1.cc
@@ -487,7 +487,7 @@ void fsobj::Recover()
 	if (!HAVEDATA(this) && cf.Length() != 0) {
 	    eprint("\t(%s, %s) cache file validation failed",
 		   comp, FID_(&fid));
-	    FSDB->FreeBlocks(NBLOCKS(cf.Length()));
+	    FSDB->FreeBlocks(NBLOCKS(cf.ValidData()));
 	    cf.Reset();
 	}
 	break;
@@ -501,8 +501,8 @@ void fsobj::Recover()
 	 * version of the object.  The stuff in RVM is the ``Vice format''
 	 * version.
 	 */
-	if (cf.Length() != 0) {
-	    FSDB->FreeBlocks(NBLOCKS(cf.Length()));
+	if (cf.ValidData() != 0) {
+	    FSDB->FreeBlocks(NBLOCKS(cf.ValidData()));
 	    cf.Reset();
 	}
 	break;
@@ -545,9 +545,9 @@ Failure:
 		DiscardData();
 		Recov_EndTrans(MAXFP);
 	    }
-	    if (cf.Length()) {
+	    if (cf.ValidData()) {
 		/* Reclaim cache-file blocks. */
-		FSDB->FreeBlocks(NBLOCKS(cf.Length()));
+		FSDB->FreeBlocks(NBLOCKS(cf.ValidData()));
 		cf.Reset();
 	    }
 	}
@@ -2374,7 +2374,7 @@ void fsobj::CacheReport(int fd, int level) {
 	    fsobj *cf = strbase(fsobj, d, child_link);
 
 	    slots++;
-	    blocks += NBLOCKS(cf->cf.Length());
+	    blocks += NBLOCKS(cf->cf.ValidData());
 	}
     }
     fdprint(fd, "[ %3d  %5d ]      ", slots, blocks);

--- a/coda-src/venus/fso1.cc
+++ b/coda-src/venus/fso1.cc
@@ -2741,6 +2741,11 @@ failure:
   return 0;
 }
 
+CacheChunkList * fsobj::GetHoles(uint64_t start, int64_t len) {
+    FSO_ASSERT(this, IsFile());
+    return cf.GetHoles(start, len);
+}
+
 /* *****  Iterator  ***** */
 
 fso_iterator::fso_iterator(LockLevel level, const VenusFid *key) : rec_ohashtab_iterator(FSDB->htab, key) {

--- a/coda-src/venus/fso_cachefile.cc
+++ b/coda-src/venus/fso_cachefile.cc
@@ -533,7 +533,7 @@ CacheChunkList * CacheFile::GetHoles(uint64_t start, int64_t len) {
     uint64_t end_b = ccblock_end(start, len);
     uint64_t length_b = bytes_to_ccblocks_ceil(length);  // Ceil length in blocks
     CacheChunkList * clist = new CacheChunkList();
-    CacheChunk currc = {};
+    CacheChunk currc;
 
     if (len < 0) {
         end_b = length_b;

--- a/coda-src/venus/fso_cfscalls2.cc
+++ b/coda-src/venus/fso_cfscalls2.cc
@@ -206,6 +206,8 @@ int fsobj::Open(int writep, int truncp, struct venus_cnode *cp, uid_t uid)
 
     if (IsSymLink())
 	return ELOOP;
+    
+    UpdateVastroFlag(uid);
 
     /*  write lock the object if we might diddle it below.  Disabling
      * replacement and bumping reference counts are performed

--- a/coda-src/venus/hdb.cc
+++ b/coda-src/venus/hdb.cc
@@ -698,6 +698,12 @@ void hdb::DataWalk(vproc *vp, int TotalBytesToFetch, int BytesFetched) {
 	    int blocks = BLOCKS(f);
 
 	    if (!HOARDABLE(f)) continue;
+        
+        if (ISVASTRO(f)) {
+            LOG(200, ("Warning (%s) flagged as VASTRO, not being hoarded.\n", 
+  		      f->comp));
+            continue;
+        }
 
 	    if (DATAVALID(f)) {
 	      LOG(200, ("AVAILABLE:  fid=<%s> comp=%s priority=%d blocks=%d\n", 

--- a/coda-src/venus/venus.cc
+++ b/coda-src/venus/venus.cc
@@ -543,6 +543,7 @@ static void Usage(char *argv0)
 " -9pfs\t\t\tenable embedded 9pfs server (experimental, INSECURE!)\n"
 " -no-codafs\t\t\tdo not automatically mount /coda\n"
 " -nofork\t\t\tdo not daemonize the process\n\n"
+" -wfmax\t\t\tmaximum file size to allow whole-file caching\n\n"
 "For more information see http://www.coda.cs.cmu.edu/\n"
 "Report bugs to <bugs@coda.cs.cmu.edu>.\n", argv0);
 }
@@ -698,6 +699,9 @@ static void ParseCmdline(int argc, char **argv)
 	    else if (STREQ(argv[i], "-nofork")) {
                 nofork = true;
 	    }
+        else if (STREQ(argv[i], "-wfmax")) {
+            i++, WholeFileMaxSize = ParseSizeWithUnits(argv[i]);
+        }	
         else if (STREQ(argv[i], "-ccbs")) {
             i++, ParseCacheChunkBlockSize(argv[i]);
         }
@@ -739,6 +743,7 @@ static void DefaultCmdlineParms()
     int DontUseRVM = 0;
     const char *CacheSize = NULL;
     const char *TmpCacheChunkBlockSize = NULL;
+    const char *TmpWFMax = NULL;
 
     /* Load the "venus.conf" configuration file */
     codaconf_init("venus.conf");
@@ -773,6 +778,11 @@ static void DefaultCmdlineParms()
         ParseCacheChunkBlockSize(TmpCacheChunkBlockSize);
     }
         
+    if (!WholeFileMaxSize) {
+        CODACONF_STR(TmpWFMax, "wholefilemaxsize", "50MB");
+        WholeFileMaxSize = ParseSizeWithUnits(TmpWFMax);
+    }
+    
     CODACONF_STR(CacheDir,	    "cachedir",      DFLT_CD);
     CODACONF_STR(SpoolDir,	    "checkpointdir", "/usr/coda/spool");
     CODACONF_STR(VenusLogFile,	    "logfile",	     DFLT_LOGFILE);

--- a/coda-src/venus/venusstats.h
+++ b/coda-src/venus/venusstats.h
@@ -48,7 +48,7 @@ extern "C" {
 
 
 #define	NVFSOPS	40	/* XXX -JJK */
-#define VFSSTATNAMELEN 12
+#define VFSSTATNAMELEN 13
 typedef struct VFSStat {
     char name[VFSSTATNAMELEN];	    /* XXX -JJK */
     int success;

--- a/coda-src/venus/vol_daemon.cc
+++ b/coda-src/venus/vol_daemon.cc
@@ -170,6 +170,8 @@ void vdb::FlushCOP2()
         for (;;) {
             int code = 0;
 
+            if (!v->IsReplicated()) continue;
+
             if (v->Enter((VM_OBSERVING | VM_NDELAY), V_UID) == 0) {
                 code = v->FlushCOP2(COP2Window);
                 v->Exit(VM_OBSERVING, V_UID);

--- a/coda-src/venus/vproc_vfscalls.cc
+++ b/coda-src/venus/vproc_vfscalls.cc
@@ -1495,7 +1495,11 @@ void vproc::read(struct venus_cnode * node, uint64_t pos, int64_t count)
 
     while (currc.isValid()) {
 
-        /* Note that all the blocks are pre-allocated for now */
+        code = FSDB->AllocBlocks(u.u_priority, NBLOCKS(currc.GetLength()));
+        if (code != 0) {
+            u.u_error = ENOSPC;
+            break;
+        }
         
         code = f->Fetch(u.u_uid, currc.GetStart(), currc.GetLength());
         if (code < 0) {

--- a/coda-src/venus/vproc_vfscalls.cc
+++ b/coda-src/venus/vproc_vfscalls.cc
@@ -1468,7 +1468,7 @@ void vproc::read(struct venus_cnode * node, uint64_t pos, int64_t count)
     int code = 0;
     fsobj *f = NULL;
     CacheChunkList * clist = NULL;
-    CacheChunk currc = {};
+    CacheChunk currc;
 
     Begin_VFS(&node->c_fid, CODA_ACCESS_INTENT, VM_OBSERVING);
 

--- a/coda-src/venus/vproc_vfscalls.cc
+++ b/coda-src/venus/vproc_vfscalls.cc
@@ -1468,6 +1468,7 @@ void vproc::read(struct venus_cnode * node, uint64_t pos, int64_t count)
     
     Begin_VFS(&node->c_fid, CODA_ACCESS_INTENT, VM_OBSERVING);
 
+
     /* Get the object. */
     f = FSDB->Find(&node->c_fid);
     if (!f) {
@@ -1478,6 +1479,7 @@ void vproc::read(struct venus_cnode * node, uint64_t pos, int64_t count)
     if (pos > f->Size()) {
         u.u_error = EIO;
         return;
+
     }
     
     End_VFS(NULL);

--- a/coda-src/venus/vproc_vfscalls.cc
+++ b/coda-src/venus/vproc_vfscalls.cc
@@ -1465,6 +1465,8 @@ void vproc::read(struct venus_cnode * node, uint64_t pos, int64_t count)
     LOG(1, ("vproc::read: fid = %s, pos = %d, count = %d\n", FID_(&node->c_fid), pos, count));
 
     fsobj *f = NULL;
+    
+    Begin_VFS(&node->c_fid, CODA_ACCESS_INTENT, VM_OBSERVING);
 
     /* Get the object. */
     f = FSDB->Find(&node->c_fid);
@@ -1477,6 +1479,8 @@ void vproc::read(struct venus_cnode * node, uint64_t pos, int64_t count)
         u.u_error = EIO;
         return;
     }
+    
+    End_VFS(NULL);
 
 }
 
@@ -1485,6 +1489,8 @@ void vproc::write(struct venus_cnode * node, uint64_t pos, int64_t count)
     LOG(1, ("vproc::write: fid = %s, pos = %d, count = %d\n", FID_(&node->c_fid), pos, count));
 
     fsobj *f = NULL;
+    
+    Begin_VFS(&node->c_fid, CODA_ACCESS_INTENT, VM_MUTATING);
 
     /* Get the object. */
     f = FSDB->Find(&node->c_fid);
@@ -1492,6 +1498,8 @@ void vproc::write(struct venus_cnode * node, uint64_t pos, int64_t count)
         u.u_error = EIO;
         return;
     }
+    
+    End_VFS(NULL);
 
 }
 
@@ -1501,6 +1509,8 @@ void vproc::read_finish(struct venus_cnode * node, uint64_t pos, int64_t count)
             FID_(&node->c_fid), pos, count));
 
     fsobj *f = NULL;
+    
+    Begin_VFS(&node->c_fid, CODA_ACCESS_INTENT, VM_OBSERVING);
 
     /* Get the object. */
     f = FSDB->Find(&node->c_fid);
@@ -1513,6 +1523,8 @@ void vproc::read_finish(struct venus_cnode * node, uint64_t pos, int64_t count)
         u.u_error = EIO;
         return;
     }
+    
+    End_VFS(NULL);
 
 }
 
@@ -1522,6 +1534,8 @@ void vproc::write_finish(struct venus_cnode * node, uint64_t pos, int64_t count)
             FID_(&node->c_fid), pos, count));
 
     fsobj *f = NULL;
+    
+    Begin_VFS(&node->c_fid, CODA_ACCESS_INTENT, VM_OBSERVING);
 
     /* Get the object. */
     f = FSDB->Find(&node->c_fid);
@@ -1529,6 +1543,8 @@ void vproc::write_finish(struct venus_cnode * node, uint64_t pos, int64_t count)
         u.u_error = EIO;
         return;
     }
+    
+    End_VFS(NULL);
 }
 
 void vproc::mmap(struct venus_cnode * node, uint64_t pos, int64_t count)
@@ -1537,6 +1553,8 @@ void vproc::mmap(struct venus_cnode * node, uint64_t pos, int64_t count)
             FID_(&node->c_fid), pos, count));
 
     fsobj *f = NULL;
+    
+    Begin_VFS(&node->c_fid, CODA_ACCESS_INTENT, VM_OBSERVING);
 
     /* Get the object. */
     f = FSDB->Find(&node->c_fid);
@@ -1544,4 +1562,6 @@ void vproc::mmap(struct venus_cnode * node, uint64_t pos, int64_t count)
         u.u_error = EIO;
         return;
     }
+    
+    End_VFS(NULL);
 }

--- a/coda-src/venus/vproc_vfscalls.cc
+++ b/coda-src/venus/vproc_vfscalls.cc
@@ -1479,7 +1479,6 @@ void vproc::read(struct venus_cnode * node, uint64_t pos, int64_t count)
     if (pos > f->Size()) {
         u.u_error = EIO;
         return;
-
     }
     
     End_VFS(NULL);

--- a/coda-src/venus/worker.cc
+++ b/coda-src/venus/worker.cc
@@ -792,8 +792,11 @@ void WorkerInit()
     if (::ioctl(worker::muxfd, CIOC_KERNEL_VERSION, &worker::kernel_version) >= 0 ) {
         switch (worker::kernel_version) {
         case 5:
+            eprint("Kernel module IS VASTRO-enabled");
+            break;
         case 4:
         case 3:
+            eprint("Kernel module IS NOT VASTRO-enabled");
             break;
         case 2: /* 1 & 2 are upwards compatible, but 3 introduced the realms */
         case 1:


### PR DESCRIPTION
This change implements;
* VASTRO files flagging (based on a single configuration parameter whole-file caching threshold)
* Add configuration parameter whole-file caching threshold
* Implement GetHoles functionality for fsobj
* Partial caching for VASTRO flagged files (fetch-on-read)
* Skip VASTROs while hoarding
* Don't pre-allocate all blocks for VASTROs. They are allocated as fetched.

Othe minor fixes included
* Add VFS Begin and End for the access intent implementations
* Fix further cache allocation issues
* Add replicated volume check for FlushCOP2