### PR TITLE
Fix missing .deps for external-src/googletest

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -239,11 +239,6 @@ coda-src/smon2/Makefile
 test-src/Makefile
 test-src/unit/Makefile])
 
-AC_CONFIG_COMMANDS_POST([
-    if test -f "${srcdir}/external-src/googletest/googletest/Makefile.am" ; then
-      automake --add-missing external-src/googletest/googletest/Makefile
-      ./config.status --file=external-src/googletest/googletest/Makefile
-    fi
-])
+CODA_SOFT_CONFIG_SUBDIR([external-src/googletest/googletest], [--with-pthreads=no])
 
 AC_OUTPUT

--- a/m4/coda_soft_config_subdir.m4
+++ b/m4/coda_soft_config_subdir.m4
@@ -1,0 +1,19 @@
+#serial 1
+dnl ---------------------------------------------
+dnl Configure a subdirectory without recursively adding
+dnl Makefile (e.g. make targets) into the build process.
+dnl Useful to prevent building unnecessary targets from
+dnl external repositories.
+dnl
+AC_DEFUN([CODA_SOFT_CONFIG_SUBDIR], [
+    if test -d "$1"; then
+        if test -f "$1/configure.ac"; then
+            autoreconf --verbose --install --no-recursive "$1"
+        fi
+
+        if test -f "$1/configure"; then
+            (cd "$1" && ./configure $2)
+        fi
+    fi
+])
+


### PR DESCRIPTION
Starting from a freshly cloned repository was making `make check` to fail because of missing content in `.deps` repositories. This new approach performs a `soft` configure of the subdirectory without including its Makefiles (e.g. make targets) into the build.