### PR TITLE
Add partial venus unittest support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,4 @@ ylwrap
 *.swp
 *~
 unittest.xml
-test-src/unit/unit
+unittest

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,12 @@ addons:
     - pkg-config
     - python
     - automake
+    - valgrind
 
 before_script:
   - ./bootstrap.sh
   - ./configure --prefix=/usr --with-lua --without-libuv
 script:
   - DISTCHECK_CONFIGURE_FLAGS=--without-libuv make -j2 distcheck
+  - make -j2 check
+  - make -j2 memcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,5 +17,5 @@ AM_DISTCHECK_CONFIGURE_FLAGS =\
 DISTCLEANFILES = unittest.xml
 
 ## Testing related
-memcheck:
+memcheck: all
 	$(MAKE) -C test-src/unit memcheck

--- a/coda-src/venus/Makefile.am
+++ b/coda-src/venus/Makefile.am
@@ -12,14 +12,15 @@ if BUILD_VENUS
 sbin_PROGRAMS += venus
 dist_man_MANS += venus.8
 dist_sysconf_DATA = venus.conf.ex realms
+noinst_LTLIBRARIES = libvenus.la
 endif
 
-venus_SOURCES = binding.cc binding.h comm.cc comm.h comm_daemon.cc daemon.cc \
+libvenus_la_SOURCES = binding.cc binding.h comm.cc comm.h comm_daemon.cc daemon.cc \
     fso.h fso0.cc fso1.cc fso_cachefile.h fso_cachefile.cc fso_cfscalls0.cc \
     fso_cfscalls1.cc fso_cfscalls2.cc fso_daemon.cc fso_dir.cc hdb.cc hdb.h \
     hdb_daemon.cc local.h local_cml.cc local_fake.cc local_fso.cc \
     local_repair.cc local_vol.cc mariner.cc mariner.h mgrp.cc mgrp.h \
-    venus.private.h venus.cc venuscb.cc venuscb.h venusfid.h venusrecov.cc \
+    venus.private.h venuscb.cc venuscb.h venusfid.h venusrecov.cc \
     venusrecov.h venusstats.h venusutil.cc venusvol.cc venusvol.h \
     vol_daemon.cc vol_cml.cc vol_reintegrate.cc vol_repair.cc vol_resolve.cc \
     vol_vcb.cc vol_COP2.cc vproc.cc vproc.h vproc_pathname.cc vproc_pioctl.cc \
@@ -27,6 +28,7 @@ venus_SOURCES = binding.cc binding.h comm.cc comm.h comm_daemon.cc daemon.cc \
     spool.cc tallyent.cc tallyent.h user.cc user.h nt_util.cc nt_util.h \
     realmdb.cc realmdb.h realm.cc realm.h rec_dllist.h refcounted.h archive.c \
     archive.h 9pfs.cc 9pfs.h SpookyV2.cc SpookyV2.h
+venus_SOURCES = venus.cc
 vutil_SOURCES = vutil.cc
 
 AM_CPPFLAGS = $(RVM_RPC2_CFLAGS) -DVENUS -DTIMING -DVENUSDEBUG \
@@ -44,7 +46,7 @@ AM_CPPFLAGS = $(RVM_RPC2_CFLAGS) -DVENUS -DTIMING -DVENUSDEBUG \
 	      -I$(top_srcdir)/coda-src/vol \
 	      -I$(top_srcdir)/coda-src/librepair
 
-venus_LDADD = $(top_builddir)/coda-src/librepair/librepio.la \
+libvenus_la_LIBADD = $(top_builddir)/coda-src/librepair/librepio.la \
 	      $(top_builddir)/coda-src/lka/liblka.la \
 	      $(top_builddir)/coda-src/vv/libvv.la \
 	      $(top_builddir)/coda-src/dir/libcodadir.la \
@@ -53,5 +55,7 @@ venus_LDADD = $(top_builddir)/coda-src/librepair/librepio.la \
 	      $(top_builddir)/lib-src/rwcdb/librwcdb.la \
 	      $(top_builddir)/lib-src/base/libbase.la \
 	      $(RVM_RPC2_LIBS)
+
+venus_LDADD = libvenus.la
 
 vutil_LDADD = $(top_builddir)/lib-src/base/libbase.la

--- a/coda-src/venus/fso_cachefile.cc
+++ b/coda-src/venus/fso_cachefile.cc
@@ -100,6 +100,7 @@ CacheFile::~CacheFile()
 {
     LOG(10, ("CacheFile::~CacheFile: %s (this=0x%x)\n", name, this));
     CODA_ASSERT(length == 0);
+    ::unlink(name);
     delete cached_chunks;
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -78,7 +78,8 @@ AC_SEARCH_LIBS(__res_search, resolv)
 AC_SEARCH_LIBS(res_9_init, resolv)
 AC_SEARCH_LIBS(kvm_openfiles, kvm)
 
-AC_CHECK_PROG([HAVE_VALGRIND_BIN], [valgrind], [1])
+VALGRIND_FLAGS="--leak-check=full --show-leak-kinds=all --error-exitcode=14"
+AC_CHECK_PROG([VALGRIND], [valgrind], [valgrind $VALGRIND_FLAGS])
 
 CODA_CHECK_LIBTERMCAP
 CODA_CHECK_LIBCURSES
@@ -166,7 +167,7 @@ AM_CONDITIONAL(BUILD_VENUS, [test "$buildclient" != no -o "$buildvenus" != no])
 AM_CONDITIONAL([HAVE_PYTHON], [test "$PYTHON" != :])
 AM_CONDITIONAL([WANT_FTS], [test "$ac_cv_header_fts_h" = no])
 
-AM_CONDITIONAL(HAVE_VALGRIND, [test "$HAVE_VALGRIND_BIN" == "1"])
+AM_CONDITIONAL(HAVE_VALGRIND, [test "x$VALGRIND" != "x"])
 
 AM_CONDITIONAL(RUN_UNIT, [test "$run_unit" != no -a -f "${srcdir}/external-src/googletest/googletest/Makefile.am"])
 
@@ -179,6 +180,12 @@ AM_COND_IF(HAVE_VALGRIND,, [
         AC_MSG_WARN([Valgrind missing, please install it before running memcheck])]
     )]
 )
+
+LIBTOOL_PREFIX="libtool --mode=execute"
+AC_SUBST(LIBTOOL_PREFIX)
+GTEST_FLAGS="--gtest_output=\"xml:unittest.xml\" --gtest_shuffle \${GTEST_EXTRA_FLAGS}"
+AC_SUBST(GTEST_FLAGS)
+AC_SUBST(VALGRIND)
 
 AC_CONFIG_FILES([coda-src/scripts/bldvldb.sh],
        [chmod +x coda-src/scripts/bldvldb.sh])
@@ -237,7 +244,8 @@ coda-src/asrlauncher/Makefile
 coda-src/vcodacon/Makefile
 coda-src/smon2/Makefile
 test-src/Makefile
-test-src/unit/Makefile])
+test-src/unit/Makefile
+test-src/unit/util/Makefile])
 
 CODA_SOFT_CONFIG_SUBDIR([external-src/googletest/googletest], [--with-pthreads=no])
 

--- a/configure.ac
+++ b/configure.ac
@@ -245,7 +245,8 @@ coda-src/vcodacon/Makefile
 coda-src/smon2/Makefile
 test-src/Makefile
 test-src/unit/Makefile
-test-src/unit/util/Makefile])
+test-src/unit/util/Makefile
+test-src/unit/venus/Makefile])
 
 CODA_SOFT_CONFIG_SUBDIR([external-src/googletest/googletest], [--with-pthreads=no])
 

--- a/lib-src/lwp/src/lwp.c
+++ b/lib-src/lwp/src/lwp.c
@@ -222,6 +222,10 @@ int LWP_TerminateProcessSupport(void)       /* terminate all LWP support */
     for_all_elts(cur, blocked, { Free_PCB(cur);})
     free((char *)lwp_init);
     lwp_init = NULL;
+
+    free(reaper.uc_stack.ss_sp);
+    free(tracer.uc_stack.ss_sp);
+
     return LWP_SUCCESS;
 }
 

--- a/lib-src/rvm/include/rvm/rds.h
+++ b/lib-src/rvm/include/rvm/rds.h
@@ -68,8 +68,16 @@ extern int rds_load_heap(
       int                   *err
     );
 
+extern int rds_unload_heap(
+      int                   *err
+    );
+
 extern int rds_start_heap(
       char                  *startAddr,
+      int                   *err
+    );
+
+extern int rds_stop_heap(
       int                   *err
     );
 

--- a/lib-src/rvm/rds/rds_start.c
+++ b/lib-src/rvm/rds/rds_start.c
@@ -45,7 +45,7 @@ heap_header_t *RecoverableHeapStartAddress;
  * avoid casts in comparisons.
  */
 free_block_t *RecoverableHeapHighAddress;
-rvm_region_def_t *RegionDefs;
+rvm_region_def_t *RegionDefs = NULL;
 unsigned long     NRegionDefs;
 rvm_bool_t       rds_testsw = rvm_false;   /* switch to allow special
                                               test modes */
@@ -107,8 +107,6 @@ rds_unload_heap(err)
     rvm_truncate();
 
     rvm_release_segment(NRegionDefs, &RegionDefs);
-
-    free(RegionDefs);
 
     rds_stop_heap(err);
 

--- a/lib-src/rvm/rds/rds_start.c
+++ b/lib-src/rvm/rds/rds_start.c
@@ -99,6 +99,22 @@ rds_load_heap(DevName, DevLength, static_addr, err)
     return 0;
 }
 
+int
+rds_unload_heap(err)
+     int	  *err;
+{
+    rvm_flush();
+    rvm_truncate();
+
+    rvm_release_segment(NRegionDefs, &RegionDefs);
+
+    free(RegionDefs);
+
+    rds_stop_heap(err);
+
+    return 0;
+}
+
 /*
  * Provide an interface which doesn't know about the segment layout.
  */
@@ -131,6 +147,16 @@ rds_start_heap(startAddr, err)
 	((char *)RecoverableHeapStartAddress +
 	    ((RDS_HEAPLENGTH - heap_hdr_len)/ RDS_CHUNK_SIZE) * RDS_CHUNK_SIZE +
 		heap_hdr_len);
+
+    *err = SUCCESS;
+    return -1;
+}
+
+int
+rds_stop_heap(err)
+     int *err;
+{
+    RecoverableHeapStartAddress = 0;
 
     *err = SUCCESS;
     return -1;

--- a/lib-src/rvm/rds/rds_zap.c
+++ b/lib-src/rvm/rds/rds_zap.c
@@ -110,4 +110,3 @@ rds_zap_heap(DevName, DevLength, startAddr, staticLength, heapLength, nlists, ch
 
     return (*err == SUCCESS ? 0 : -1);
 }
-

--- a/lib-src/rvm/rvm/rvm_init.c
+++ b/lib-src/rvm/rvm/rvm_init.c
@@ -137,6 +137,9 @@ rvm_return_t rvm_terminate(void)
         inited = rvm_false;
         terminated = rvm_true;
 
+        /* Clean free lists */
+        clear_free_lists();
+
 err_exit:;
         });                             /* end init_lock crit sec */
 

--- a/lib-src/rvm/rvm/rvm_map.c
+++ b/lib-src/rvm/rvm/rvm_map.c
@@ -480,7 +480,7 @@ rvm_return_t close_all_segs()
 
     RW_CRITICAL(seg_root_lock,w,        /* begin seg_root_lock crit section */
         {
-        FOR_ENTRIES_OF(seg_root,seg_t,seg)
+        UNLINK_ENTRIES_OF(seg_root,seg_t,seg)
             {
             CRITICAL(seg->dev_lock,     /* begin seg->dev_lock crit section */
                 {
@@ -489,6 +489,7 @@ rvm_return_t close_all_segs()
                 });                     /* end seg->dev_lock crit section */
             if (retval != RVM_SUCCESS)
                 break;
+            free_seg(seg);
             }
         });                             /* end seg_root_lock crit section */
 
@@ -878,6 +879,7 @@ static rvm_return_t chk_dependencies(seg,region)
                     if ((retval=wait_for_truncation(seg->log,
                                                 &x_region->unmap_ts))
                         != RVM_SUCCESS) goto err_exit;
+                    free_mem_region(x_region->mem_region);
                     free_region(x_region); /* can free now */
                     }
                 else break;             /* no further dependencies */

--- a/lib-src/rvm/rvm/rvm_private.h
+++ b/lib-src/rvm/rvm/rvm_private.h
@@ -1157,8 +1157,7 @@ list_entry_t *alloc_list_entry();        /* [rvm_utils.c] */
 /* internal type allocators/deallocators */
 
 extern
-void clear_free_list();                 /* [rvm_utils.c] */
-/*  struct_id_t     id; */
+void clear_free_lists();                 /* [rvm_utils.c] */
 
 extern
 region_t *make_region();                /* [rvm_utils.c] */

--- a/lib-src/rvm/rvm/rvm_unmap.c
+++ b/lib-src/rvm/rvm/rvm_unmap.c
@@ -88,6 +88,7 @@ rvm_return_t rvm_unmap(rvm_region)
                                   (list_entry_t *)region);
             }
         else
+        free_mem_region(region->mem_region);
             free_region(region);
         });                             /* end seg_lock critical section */
 

--- a/lib-src/rvm/seg/rvm_createseg.c
+++ b/lib-src/rvm/seg/rvm_createseg.c
@@ -55,7 +55,7 @@ rvm_create_segment(DevName, DevLength, options, nregions, regionDefs)
 
     /* Map in the first RVM_SEGMENT_HDR_SIZE bytes of the segment */
     
-    region->data_dev = DevName;
+    region->data_dev = strdup(DevName);
     region->dev_length = DevLength;
     RVM_ZERO_OFFSET(region->offset);
     region->length = RVM_SEGMENT_HDR_SIZE;

--- a/lib-src/rvm/seg/rvm_loadseg.c
+++ b/lib-src/rvm/seg/rvm_loadseg.c
@@ -53,7 +53,7 @@ rvm_load_segment(char *DevName, rvm_offset_t DevLength, rvm_options_t *options,
     /* HACK */ rds_rvmsize = 0; /* HACK */
     
     /* Read in the header region of the segment. */
-    hdr_region->data_dev = DevName;
+    hdr_region->data_dev = strdup(DevName);
     hdr_region->dev_length = DevLength;		/* Struct assignment */
     RVM_ZERO_OFFSET(hdr_region->offset);
     hdr_region->length = RVM_SEGMENT_HDR_SIZE;
@@ -87,7 +87,7 @@ rvm_load_segment(char *DevName, rvm_offset_t DevLength, rvm_options_t *options,
 	return RVM_EVM_OVERLAP;
     
     /* Map in the regions */
-    region->data_dev = DevName; 
+    region->data_dev = strdup(DevName); 
     region->dev_length = DevLength;		/* Struct assignment */
     
     /* Setup return region definition array */
@@ -135,5 +135,7 @@ rvm_load_segment(char *DevName, rvm_offset_t DevLength, rvm_options_t *options,
     err = deallocate_vm(hdr_region->vmaddr, hdr_region->length);
 
     rvm_free_region(hdr_region);
+    rvm_free_region(region);
     return err;
 }
+

--- a/lib-src/rvm/seg/rvm_releaseseg.c
+++ b/lib-src/rvm/seg/rvm_releaseseg.c
@@ -42,8 +42,11 @@ rvm_release_segment (
         if (err != RVM_SUCCESS)
             printf("release_segment unmap failed %s\n", rvm_return(err));
 
+        rvm_unregister_page(region->vmaddr, region->length);
         deallocate_vm(region->vmaddr, region->length);
+
     }
+    
     rvm_free_region(region);
     free(*regions);
     return err;

--- a/test-src/unit/Makefile.am
+++ b/test-src/unit/Makefile.am
@@ -2,9 +2,11 @@
 
 check_PROGRAMS = unit
 
+LIB_SRC = lib/rvm/rvm.cc lib/lwp/lwp.cc
+
 UTIL_TESTS = util/u_bitmap.cc
 
-unit_SOURCES = main.cc $(UTIL_TESTS)
+unit_SOURCES = main.cc $(UTIL_TESTS) $(LIB_SRC)
 
 GTEST_DIR = $(top_builddir)/external-src/googletest/googletest
 
@@ -14,9 +16,12 @@ unit_LDADD = $(top_builddir)/coda-src/util/libutil.la \
              $(RVM_RPC2_LIBS)
 
 AM_CPPFLAGS = $(RVM_RPC2_CFLAGS) -DVENUS -DTIMING -DVENUSDEBUG \
+              -I$(top_srcdir)/test-src/unit/include \
               -I$(top_srcdir)/lib-src/base \
               -I$(top_srcdir)/coda-src \
-              -I$(top_builddir)/coda-src
+              -I$(top_srcdir)/coda-src/util \
+              -I$(top_builddir)/coda-src \
+              -I$(GTEST_DIR)/include
 
 LIBTOOL = libtool --mode=execute
 GTEST_FLAGS = --gtest_output="xml:$(top_builddir)/unittest.xml" --gtest_shuffle

--- a/test-src/unit/Makefile.am
+++ b/test-src/unit/Makefile.am
@@ -4,7 +4,7 @@ check_PROGRAMS = unit
 
 LIB_SRC = lib/rvm/rvm.cc lib/lwp/lwp.cc
 
-UTIL_TESTS = util/u_bitmap.cc
+UTIL_TESTS = util/u_bitmap.cc util/u_test_rvm.cc
 
 unit_SOURCES = main.cc $(UTIL_TESTS) $(LIB_SRC)
 

--- a/test-src/unit/Makefile.am
+++ b/test-src/unit/Makefile.am
@@ -4,6 +4,8 @@ check_LTLIBRARIES = libmain_test.la librecov.la
 
 SUBDIRS = . util venus
 
+MEMCHECK_SUBDIRS := $(filter-out ., $(SUBDIRS))
+
 LIB_SRC = lib/rvm/rvm.cc lib/lwp/lwp.cc
 
 libmain_test_la_SOURCES = main.cc $(LIB_SRC)
@@ -26,9 +28,14 @@ distclean-local:
 	if test -f "${GTEST_DIR}/Makefile"; then make -C $(GTEST_DIR) distclean; fi
 
 
-memcheck:
-	$(MAKE) -C util memcheck
-	$(MAKE) -C venus memcheck
-
 check-local:
 	$(MAKE) -C $(GTEST_DIR) lib/libgtest.la
+
+$(MEMCHECK_SUBDIRS):
+	$(MAKE) -C $@ memcheck
+	echo $@
+
+memcheck: $(MEMCHECK_SUBDIRS)
+
+.PHONY: $(MEMCHECK_SUBDIRS)
+.NOTPARALLEL: $(MEMCHECK_SUBDIRS)

--- a/test-src/unit/Makefile.am
+++ b/test-src/unit/Makefile.am
@@ -1,19 +1,15 @@
 ## Process this file with automake to produce Makefile.in
 
-check_PROGRAMS = unit
+check_LTLIBRARIES = libmain_test.la librecov.la
+
+SUBDIRS = . util
 
 LIB_SRC = lib/rvm/rvm.cc lib/lwp/lwp.cc
 
-UTIL_TESTS = util/u_bitmap.cc util/u_test_rvm.cc
-
-unit_SOURCES = main.cc $(UTIL_TESTS) $(LIB_SRC)
+libmain_test_la_SOURCES = main.cc $(LIB_SRC)
+librecov_la_SOURCES = lib/rvm/recov.cc
 
 GTEST_DIR = $(top_builddir)/external-src/googletest/googletest
-
-unit_LDADD = $(top_builddir)/coda-src/util/libutil.la \
-             $(top_builddir)/lib-src/base/libbase.la \
-             $(GTEST_DIR)/lib/libgtest.la \
-             $(RVM_RPC2_LIBS)
 
 AM_CPPFLAGS = $(RVM_RPC2_CFLAGS) -DVENUS -DTIMING -DVENUSDEBUG \
               -I$(top_srcdir)/test-src/unit/include \
@@ -23,23 +19,15 @@ AM_CPPFLAGS = $(RVM_RPC2_CFLAGS) -DVENUS -DTIMING -DVENUSDEBUG \
               -I$(top_builddir)/coda-src \
               -I$(GTEST_DIR)/include
 
-LIBTOOL = libtool --mode=execute
-GTEST_FLAGS = --gtest_output="xml:$(top_builddir)/unittest.xml" --gtest_shuffle
-VALGRIND_FLAGS = --leak-check=full --show-leak-kinds=all
-UNIT_BIN = $(top_builddir)/test-src/unit/unit
-
-
-$(GTEST_DIR)/lib/libgtest.la:
-	$(MAKE) -C $(GTEST_DIR) lib/libgtest.la
-
 clean-local:
 	if test -f "${GTEST_DIR}/Makefile"; then make -C $(GTEST_DIR) clean; fi
 
 distclean-local:
 	if test -f "${GTEST_DIR}/Makefile"; then make -C $(GTEST_DIR) distclean; fi
 
-check-local: unit
-	${LIBTOOL} ${UNIT_BIN} ${GTEST_FLAGS} ${GTEST_EXTRA_FLAGS}
 
-memcheck: unit
-	${LIBTOOL} valgrind ${VALGRIND_FLAGS} ${UNIT_BIN} ${GTEST_FLAGS} ${GTEST_EXTRA_FLAGS}
+memcheck:
+	$(MAKE) -C util memcheck
+
+check-local:
+	$(MAKE) -C $(GTEST_DIR) lib/libgtest.la

--- a/test-src/unit/Makefile.am
+++ b/test-src/unit/Makefile.am
@@ -2,7 +2,7 @@
 
 check_LTLIBRARIES = libmain_test.la librecov.la
 
-SUBDIRS = . util
+SUBDIRS = . util venus
 
 LIB_SRC = lib/rvm/rvm.cc lib/lwp/lwp.cc
 
@@ -28,6 +28,7 @@ distclean-local:
 
 memcheck:
 	$(MAKE) -C util memcheck
+	$(MAKE) -C venus memcheck
 
 check-local:
 	$(MAKE) -C $(GTEST_DIR) lib/libgtest.la

--- a/test-src/unit/include/test/lwp/lwp.h
+++ b/test-src/unit/include/test/lwp/lwp.h
@@ -1,0 +1,38 @@
+/* BLURB gpl
+
+                           Coda File System
+                              Release 7
+
+          Copyright (c) 1987-2018 Carnegie Mellon University
+                  Additional copyrights listed below
+
+This  code  is  distributed "AS IS" without warranty of any kind under
+the terms of the GNU General Public Licence Version 2, as shown in the
+file  LICENSE.  The  technical and financial  contributors to Coda are
+listed in the file CREDITS.
+
+                        Additional copyrights
+                           none currently
+
+#*/
+
+#ifndef	_TEST_LWP_H_
+#define _TEST_LWP_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+/* from util */
+#include <util/rvmlib.h>
+
+void LWPInit();
+void LWPUnInit();
+
+#endif /* _TEST_LWP_H_ */

--- a/test-src/unit/include/test/rvm/recov.h
+++ b/test-src/unit/include/test/rvm/recov.h
@@ -1,0 +1,43 @@
+/* BLURB gpl
+
+                           Coda File System
+                              Release 7
+
+          Copyright (c) 1987-2018 Carnegie Mellon University
+                  Additional copyrights listed below
+
+This  code  is  distributed "AS IS" without warranty of any kind under
+the terms of the GNU General Public Licence Version 2, as shown in the
+file  LICENSE.  The  technical and financial  contributors to Coda are
+listed in the file CREDITS.
+
+                        Additional copyrights
+                           none currently
+
+#*/
+#ifndef _TEST_RECOV_H_
+#define _TEST_RECOV_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+/* from util */
+#include <util/rvmlib.h>
+
+/* Transaction handling */
+void _Recov_BeginTrans(const char file[], int line);
+
+void Recov_EndTrans(int time);
+
+void Recov_AbortTrans();
+
+#define Recov_BeginTrans() _Recov_BeginTrans(__FILE__, __LINE__)
+
+#endif /* _TEST_RECOV_H_ */

--- a/test-src/unit/include/test/rvm/rvm.h
+++ b/test-src/unit/include/test/rvm/rvm.h
@@ -1,0 +1,66 @@
+/* BLURB gpl
+
+                           Coda File System
+                              Release 7
+
+          Copyright (c) 1987-2018 Carnegie Mellon University
+                  Additional copyrights listed below
+
+This  code  is  distributed "AS IS" without warranty of any kind under
+the terms of the GNU General Public Licence Version 2, as shown in the
+file  LICENSE.  The  technical and financial  contributors to Coda are
+listed in the file CREDITS.
+
+                        Additional copyrights
+                           none currently
+
+#*/
+
+#ifndef	_TEST_RVM_H_
+#define _TEST_RVM_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+/* from util */
+#include <util/rvmlib.h>
+
+const double DefaultStaticHeapRatio = 0.8;
+const int DataToLogSizeRatio = 4;
+const int DefaultDataDeviceSize = 10 * 1024 * 1024; // 10MB
+
+const unsigned long MinDataDeviceSize = 0x080000;
+const unsigned long MinLogDeviceSize = MinDataDeviceSize / DataToLogSizeRatio;
+
+const int DFLT_RDSCS = 64;		/* RDS chunk size */
+const int DFLT_RDSNL = 16;		/* RDS nlists */
+
+
+#define INIT_RVM_CONFIG(config) config.configInit = true; \
+                                (void*)tmpnam_r(config.LogDevice); \
+                                (void*)tmpnam_r(config.DataDevice); \
+                                config.staticHeapRatio = DefaultStaticHeapRatio; \
+                                config.DataDeviceSize = DefaultDataDeviceSize; \
+                                config.LogDeviceSize = config.DataDeviceSize / DataToLogSizeRatio;\
+                                
+
+struct rvm_config {
+    bool configInit;
+    char LogDevice[L_tmpnam];
+    unsigned long LogDeviceSize;
+    char DataDevice[L_tmpnam];
+    unsigned long DataDeviceSize;
+    double staticHeapRatio;
+};
+
+void RVMInit(struct rvm_config config);
+void RVMDestroy(struct rvm_config config);
+
+#endif /* _TEST_RVM_H_ */

--- a/test-src/unit/lib/lwp/lwp.cc
+++ b/test-src/unit/lib/lwp/lwp.cc
@@ -1,0 +1,99 @@
+/* BLURB gpl
+
+                           Coda File System
+                              Release 7
+
+          Copyright (c) 1987-2018 Carnegie Mellon University
+                  Additional copyrights listed below
+
+This  code  is  distributed "AS IS" without warranty of any kind under
+the terms of the GNU General Public Licence Version 2, as shown in the
+file  LICENSE.  The  technical and financial  contributors to Coda are
+listed in the file CREDITS.
+
+                        Additional copyrights
+                           none currently
+
+#*/
+
+/* external */
+#include <gtest/gtest.h>
+
+/* from test */
+#include <test/rvm/rvm.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdint.h>
+#include <stdlib.h>
+
+/* from lwp */
+#include <lwp/lock.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+PROCESS lwpid;
+bool initialized =  false;
+uint32_t init_ref_count = 0;
+FILE * _logFile = NULL;
+rvm_perthread_t rvmptt;
+
+void LWPInit() {
+    int lwprc = 0;
+    int iomgrrc = 0;
+
+    if (initialized) {
+        init_ref_count++;
+        return;
+    }
+
+    /* Initialize the LWP subsystem. */
+    lwprc = LWP_Init(LWP_VERSION, LWP_NORMAL_PRIORITY, &lwpid);
+    ASSERT_EQ(lwprc, LWP_SUCCESS) << "LWP_Init failed";
+
+    memset(&rvmptt, 0, sizeof(rvm_perthread_t));
+
+    rvmlib_init_threaddata(&rvmptt);
+
+    iomgrrc = IOMGR_Initialize();
+    ASSERT_EQ(iomgrrc, LWP_SUCCESS) << "IOMGR_Initialize failed";
+
+    _logFile = tmpfile();
+    ASSERT_TRUE(_logFile) << "Unable to create log file";\
+
+    LWP_SetLog(_logFile, 0);
+
+    initialized = true;
+    init_ref_count++;
+
+}
+
+void LWPUnInit() {
+    int lwprc = 0;
+    int iomgrrc = 0;
+    int ret = 0;
+
+    if (initialized) init_ref_count--;
+
+    if (init_ref_count) return;
+
+    ret = fclose(_logFile);
+    ASSERT_EQ(ret, 0) << "Unable to close log file";
+
+    iomgrrc = IOMGR_Finalize();
+    ASSERT_EQ(iomgrrc, LWP_SUCCESS) << "IOMGR_Finalize failed";
+
+    lwprc = LWP_TerminateProcessSupport();
+    ASSERT_EQ(lwprc, LWP_SUCCESS) << "LWP_TerminateProcessSupport failed";
+
+
+    initialized = false;
+}

--- a/test-src/unit/lib/rvm/recov.cc
+++ b/test-src/unit/lib/rvm/recov.cc
@@ -1,0 +1,34 @@
+/* BLURB gpl
+
+                           Coda File System
+                              Release 7
+
+          Copyright (c) 1987-2018 Carnegie Mellon University
+                  Additional copyrights listed below
+
+This  code  is  distributed "AS IS" without warranty of any kind under
+the terms of the GNU General Public Licence Version 2, as shown in the
+file  LICENSE.  The  technical and financial  contributors to Coda are
+listed in the file CREDITS.
+
+                        Additional copyrights
+                           none currently
+
+#*/
+
+#include <test/rvm/recov.h>
+
+/* Transaction handling */
+void _Recov_BeginTrans(const char file[], int line)
+{
+    _rvmlib_begin_transaction(no_restore, file, line);
+}
+
+void Recov_EndTrans(int time)
+{
+    rvmlib_end_transaction(no_flush, 0);
+}
+
+void Recov_AbortTrans() {
+    rvmlib_abort(0);
+}

--- a/test-src/unit/lib/rvm/rvm.cc
+++ b/test-src/unit/lib/rvm/rvm.cc
@@ -1,0 +1,180 @@
+/* BLURB gpl
+
+                           Coda File System
+                              Release 7
+
+          Copyright (c) 1987-2018 Carnegie Mellon University
+                  Additional copyrights listed below
+
+This  code  is  distributed "AS IS" without warranty of any kind under
+the terms of the GNU General Public Licence Version 2, as shown in the
+file  LICENSE.  The  technical and financial  contributors to Coda are
+listed in the file CREDITS.
+
+                        Additional copyrights
+                           none currently
+
+#*/
+
+/* external */
+#include <gtest/gtest.h>
+
+/* from test */
+#include <test/rvm/rvm.h>
+#include <test/lwp/lwp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdlib.h>
+#include <fcntl.h>
+
+#ifdef HAVE_OSRELDATE_H
+#include <osreldate.h>
+#endif
+
+/* from rvm */
+#include <rvm/rds.h>
+#include <rvm/rvm.h>
+#include <rvm/rvm_segment.h>
+#include <rvm/rvm_statistics.h>
+#include <test/rvm/rvm.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+static const char *VM_RVMADDR = (char *)0x50000000;
+
+#ifndef MAX
+#define MAX(a,b)  ( ((a) > (b)) ? (a) : (b) )
+#endif
+
+#ifndef O_BINARY
+#define O_BINARY 0
+#endif
+
+/*  *****  Private Variables  *****  */
+
+static rvm_options_t Recov_Options;
+static char *Recov_RvgAddr = 0;
+static rvm_length_t Recov_RvgLength = 0;
+static char *Recov_RdsAddr = 0;
+static rvm_length_t Recov_RdsLength = 0;
+static rvm_statistics_t Recov_Statistics;
+
+
+static void Recov_CheckParms(struct rvm_config config)
+{
+    ASSERT_EQ(config.configInit, true);
+    ASSERT_GE(config.LogDeviceSize, MinLogDeviceSize) << "RVM log segment too small";
+    ASSERT_GE(config.DataDeviceSize, MAX(config.LogDeviceSize, MinDataDeviceSize)) << "RVM data segment too small";
+}
+
+static void Recov_InitRVM(struct rvm_config config)
+{
+    rvm_return_t ret;
+    char *logdev = strdup(config.LogDevice);
+
+    rvm_init_options(&Recov_Options);
+    Recov_Options.log_dev = logdev;
+    Recov_Options.truncate = 0;
+    //Recov_Options.flags = RVM_COALESCE_TRANS;  /* oooh, daring */
+    Recov_Options.flags = RVM_ALL_OPTIMIZATIONS;
+    Recov_Options.flags |= RVM_MAP_PRIVATE;
+
+    rvm_init_statistics(&Recov_Statistics);
+
+    /* Get rid of any old log */
+    unlink(config.LogDevice);
+
+    /* Pass in the correct parameters so that RVM_INIT can create
+        * a new logfile */
+    Recov_Options.create_log_file = rvm_true;
+    Recov_Options.create_log_size = RVM_MK_OFFSET(0, config.LogDeviceSize);
+    Recov_Options.create_log_mode = 0600;
+    /* as far as the log is concerned RVM_INIT will now handle the
+        * rest of the creation. */
+
+    LWPInit();
+
+    ret = RVM_INIT(&Recov_Options);
+    free(logdev);
+
+    if (ret != RVM_SUCCESS) RVMDestroy(config);
+
+    ASSERT_NE(ret, RVM_ELOG_VERSION_SKEW) << "RVM_INIT failed, destroying RVM ... ";
+    ASSERT_EQ(ret, RVM_SUCCESS) << "RVM_INIT failed";
+}
+
+static void Recov_InitRDS(struct rvm_config config)
+{
+    rvm_return_t ret = 0;
+    rvm_length_t devsize = 0;
+    int fd = 0;
+    int u_ret = 0;
+
+    devsize = RVM_ROUND_LENGTH_DOWN_TO_PAGE_SIZE(config.DataDeviceSize);
+    Recov_RdsAddr = (char *)VM_RVMADDR;
+    Recov_RvgLength= RVM_ROUND_LENGTH_UP_TO_PAGE_SIZE(config.staticHeapRatio * config.DataDeviceSize);
+    Recov_RdsLength= devsize - Recov_RvgLength - RVM_SEGMENT_HDR_SIZE;
+
+    /* Initialize data segment. */
+
+    fd = open(config.DataDevice, O_WRONLY|O_CREAT|O_TRUNC|O_BINARY, 0600);
+    ASSERT_NE(fd, 0) << "Couldn't open RVM data device";
+
+    u_ret = ftruncate(fd, config.DataDeviceSize);
+    ASSERT_EQ(u_ret, 0) << "Couldn't truncate RVM data device";
+
+    u_ret = close(fd);
+    ASSERT_EQ(u_ret, 0) << "Couldn't close RVM data device";
+
+    rds_zap_heap(config.DataDevice, RVM_LENGTH_TO_OFFSET(devsize),
+                 Recov_RdsAddr,
+                 Recov_RvgLength,
+                 Recov_RdsLength,
+                 (unsigned long)DFLT_RDSNL,
+                 (unsigned long)DFLT_RDSCS, 
+                 &ret);
+    ASSERT_EQ(ret, SUCCESS) << "rds_zap_heap failed";
+
+    rds_load_heap(config.DataDevice, RVM_LENGTH_TO_OFFSET(config.DataDeviceSize), &Recov_RvgAddr, &ret);
+    ASSERT_EQ(ret, SUCCESS) << "rds_load_heap failed";
+}
+
+void RVMInit(struct rvm_config config)
+{
+    /* Set unset parameters to defaults (as appropriate). */
+    Recov_CheckParms(config);
+
+    /* Initialize the RVM package. */
+    Recov_InitRVM(config);
+    Recov_InitRDS(config);
+}
+
+void RVMDestroy(struct rvm_config config)
+{
+    int ret = 0;
+    rvm_return_t rvmret = 0;
+
+    rds_unload_heap(&ret);
+    EXPECT_EQ(ret, 0) << "Error unloading heap";
+
+    rvmret = rvm_terminate();
+    EXPECT_EQ(rvmret, RVM_SUCCESS) << "Unable to terminate RVM";
+
+
+    /* Remove log and data files */
+    ret = unlink(config.LogDevice);
+    EXPECT_EQ(ret, 0) << "Unable to delete log device";
+    ret = unlink(config.DataDevice);
+    EXPECT_EQ(ret, 0) << "Unable to delete data device";
+
+    LWPUnInit();
+}

--- a/test-src/unit/main.cc
+++ b/test-src/unit/main.cc
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     seed = ::testing::GTEST_FLAG(random_seed);
 
     if (seed == 0) {
-        seed = time(nullptr) & 0xFFFF;
+        seed = time(NULL) & 0xFFFF;
         ::testing::GTEST_FLAG(random_seed) = seed;
     }
 

--- a/test-src/unit/main.cc
+++ b/test-src/unit/main.cc
@@ -4,10 +4,22 @@
 
 #include <gtest/gtest.h>
 
+#include <test/rvm/rvm.h>
+
 int main(int argc, char **argv) {
+    struct rvm_config config;
     int32_t seed = 0;
+    int ret = 0;
     printf("Running main() from %s\n", __FILE__);
     testing::InitGoogleTest(&argc, argv);
+
+
+    INIT_RVM_CONFIG(config)
+
+    RvmType = UFS;
+
+    RVMInit(config);
+
 
     /* Get the random seed used by gtest */
     seed = ::testing::GTEST_FLAG(random_seed);
@@ -19,5 +31,9 @@ int main(int argc, char **argv) {
 
     srand(seed);
 
-    return RUN_ALL_TESTS();
+    ret = RUN_ALL_TESTS();
+
+    RVMDestroy(config);
+
+    return ret;
 }

--- a/test-src/unit/main.cc
+++ b/test-src/unit/main.cc
@@ -6,6 +6,10 @@
 
 #include <test/rvm/rvm.h>
 
+char dir_template[] = "/tmp/cachedir.XXXXXX";
+
+char * CacheDir;
+
 int main(int argc, char **argv) {
     struct rvm_config config;
     int32_t seed = 0;
@@ -13,6 +17,13 @@ int main(int argc, char **argv) {
     printf("Running main() from %s\n", __FILE__);
     testing::InitGoogleTest(&argc, argv);
 
+    CacheDir = mkdtemp(dir_template);
+    printf("Changing to CacheDir %s\n", CacheDir);
+    if (chdir(CacheDir)) {
+        perror("CacheDir chdir");
+        exit(EXIT_FAILURE);
+    }
+    
 
     INIT_RVM_CONFIG(config)
 

--- a/test-src/unit/util/Makefile.am
+++ b/test-src/unit/util/Makefile.am
@@ -1,0 +1,28 @@
+## Process this file with automake to produce Makefile.in
+
+check_PROGRAMS = unittest
+
+unittest_SOURCES = u_bitmap.cc u_test_rvm.cc
+
+GTEST_DIR = $(top_builddir)/external-src/googletest/googletest
+
+unittest_LDADD = $(top_builddir)/coda-src/util/libutil.la \
+             $(top_builddir)/lib-src/base/libbase.la \
+             $(top_builddir)/test-src/unit/.libs/libmain_test.la \
+             $(GTEST_DIR)/lib/libgtest.la \
+             $(top_builddir)/test-src/unit/.libs/librecov.la \
+             $(RVM_RPC2_LIBS)
+
+AM_CPPFLAGS = $(RVM_RPC2_CFLAGS) -DVENUS -DTIMING -DVENUSDEBUG \
+              -I$(top_srcdir)/test-src/unit/include \
+              -I$(top_srcdir)/lib-src/base \
+              -I$(top_srcdir)/coda-src \
+              -I$(top_srcdir)/coda-src/util \
+              -I$(top_builddir)/coda-src \
+              -I$(GTEST_DIR)/include
+
+check-local: unittest
+	@LIBTOOL_PREFIX@ ./unittest @GTEST_FLAGS@
+
+memcheck: unittest
+	@LIBTOOL_PREFIX@ @VALGRIND@ ./unittest @GTEST_FLAGS@

--- a/test-src/unit/util/u_bitmap.cc
+++ b/test-src/unit/util/u_bitmap.cc
@@ -1,15 +1,46 @@
+/* BLURB gpl
+
+                           Coda File System
+                              Release 7
+
+          Copyright (c) 1987-2018 Carnegie Mellon University
+                  Additional copyrights listed below
+
+This  code  is  distributed "AS IS" without warranty of any kind under
+the terms of the GNU General Public Licence Version 2, as shown in the
+file  LICENSE.  The  technical and financial  contributors to Coda are
+listed in the file CREDITS.
+
+                        Additional copyrights
+                           none currently
+
+#*/
+/* system */
+
+/* external */
+#include <gtest/gtest.h>
+
+/* from coda-src */
 #include <util/bitmap.h>
-#include "gtest/gtest.h"
+
+/* from test-src */
+#include <test/rvm/rvm.h>
+#include <test/rvm/recov.h>
 
 namespace {
 
 // bitmap.
 TEST(bitmap, assign) {
     int16_t bitmap_size = rand() & 0x7FFF;
+    int recoverable_1 = rand() & 0x1;
+    int recoverable_2 = rand() & 0x1;
     int16_t i = 0;
 
-    bitmap * src = new (0) bitmap(bitmap_size, 0);
-    bitmap * dst = new (0) bitmap(bitmap_size, 0);
+    Recov_BeginTrans();
+
+    bitmap * src = new (recoverable_1) bitmap(bitmap_size, recoverable_1);
+    bitmap * dst = new (recoverable_2) bitmap(bitmap_size, recoverable_2);
+
     EXPECT_GE(src->Size(), bitmap_size);
     EXPECT_GE(dst->Size(), bitmap_size);
 
@@ -30,6 +61,7 @@ TEST(bitmap, assign) {
     delete (src);
     delete (dst);
 
+    Recov_EndTrans(0);
 }
 
 TEST(bitmap, copy) {
@@ -37,9 +69,13 @@ TEST(bitmap, copy) {
     int16_t i = 0;
     int16_t start = rand() % bitmap_size;
     int16_t len = rand() % bitmap_size;
+    int recoverable_1 = rand() & 0x1;
+    int recoverable_2 = rand() & 0x1;
 
-    bitmap * src = new (0) bitmap(bitmap_size, 0);
-    bitmap * dst = new (0) bitmap(bitmap_size, 0);
+    Recov_BeginTrans();
+
+    bitmap * src = new (recoverable_1) bitmap(bitmap_size, recoverable_1);
+    bitmap * dst = new (recoverable_2) bitmap(bitmap_size, recoverable_2);
 
     EXPECT_GE(src->Size(), bitmap_size);
     EXPECT_GE(dst->Size(), bitmap_size);
@@ -64,15 +100,21 @@ TEST(bitmap, copy) {
     delete (src);
     delete (dst);
 
+    Recov_EndTrans(0);
+
 }
 
 TEST(bitmap, assign_different_size) {
     int16_t bitmap_size_1 = rand() & 0x7FFF;
     int16_t bitmap_size_2 = rand() & 0x7FFF;
     int16_t i = 0;
+    int recoverable_1 = rand() & 0x1;
+    int recoverable_2 = rand() & 0x1;
 
-    bitmap * src = new (0) bitmap(bitmap_size_1, 0);
-    bitmap * dst = new (0) bitmap(bitmap_size_2, 0);
+    Recov_BeginTrans();
+
+    bitmap * src = new (recoverable_1) bitmap(bitmap_size_1, recoverable_1);
+    bitmap * dst = new (recoverable_2) bitmap(bitmap_size_2, recoverable_2);
 
     EXPECT_GE(src->Size(), bitmap_size_1);
     EXPECT_GE(dst->Size(), bitmap_size_2);
@@ -96,14 +138,19 @@ TEST(bitmap, assign_different_size) {
     delete (src);
     delete (dst);
 
+    Recov_EndTrans(0);
+
 }
 
 TEST(bitmap, resize) {
     int16_t bitmap_size_start = rand() & 0x7FFF;
     int16_t bitmap_size_end = rand() & 0x7FFF;
     int16_t i = 0;
+    int recoverable = rand() & 0x1;
 
-    bitmap * bm = new (0) bitmap(bitmap_size_start, 0);
+    Recov_BeginTrans();
+
+    bitmap * bm = new (recoverable) bitmap(bitmap_size_start, recoverable);
 
     EXPECT_GE(bm->Size(), bitmap_size_start);
 
@@ -124,14 +171,19 @@ TEST(bitmap, resize) {
 
     delete (bm);
 
+    Recov_EndTrans(0);
+
 }
 
 TEST(bitmap, set_range) {
     int16_t bitmap_size = rand() & 0x7FFF;
     int16_t start = rand() % bitmap_size;
     int16_t len = rand() % bitmap_size;
+    int recoverable = rand() & 0x1;
 
-    bitmap * bm = new (0) bitmap(bitmap_size, 0);
+    Recov_BeginTrans();
+
+    bitmap * bm = new (recoverable) bitmap(bitmap_size, recoverable);
 
     EXPECT_GE(bm->Size(), bitmap_size);
 
@@ -156,15 +208,20 @@ TEST(bitmap, set_range) {
 
     delete (bm);
 
+    Recov_EndTrans(0);
 }
 
 TEST(bitmap, set_range_and_copy_till_end) {
     int16_t bitmap_size = rand() & 0x7FFF;
     int16_t start = rand() % bitmap_size;
     int16_t len = -1;
+    int recoverable_1 = rand() & 0x1;
+    int recoverable_2 = rand() & 0x1;
 
-    bitmap * bm = new (0) bitmap(bitmap_size, 0);
-    bitmap * bm_cpy = new (0) bitmap(bitmap_size, 0);
+    Recov_BeginTrans();
+
+    bitmap * bm = new (recoverable_1) bitmap(bitmap_size, recoverable_1);
+    bitmap * bm_cpy = new (recoverable_2) bitmap(bitmap_size, recoverable_2);
 
     EXPECT_GE(bm->Size(), bitmap_size);
     EXPECT_GE(bm_cpy->Size(), bitmap_size);
@@ -186,26 +243,36 @@ TEST(bitmap, set_range_and_copy_till_end) {
     delete (bm);
     delete (bm_cpy);
 
+    Recov_EndTrans(0);
+
 }
 
 TEST(bitmap, purge_delete) {
     int16_t bitmap_size = rand() & 0x7FFF;
+    int recoverable = rand() & 0x1;
 
-    bitmap * bm = new (0) bitmap(bitmap_size, 0);
+    Recov_BeginTrans();
+
+    bitmap * bm = new (recoverable) bitmap(bitmap_size, recoverable);
 
     EXPECT_GE(bm->Size(), bitmap_size);
 
     bm->purge();
 
     delete (bm);
+
+    Recov_EndTrans(0);
 }
 
 TEST(bitmap, get_free_index) {
     int16_t bitmap_size = rand() & 0x7FFF;
     int16_t i = 0;
     int16_t current_index = 0;
+    int recoverable = rand() & 0x1;
 
-    bitmap * bm = new (0) bitmap(bitmap_size, 0);
+    Recov_BeginTrans();
+
+    bitmap * bm = new (recoverable) bitmap(bitmap_size, recoverable);
     
     EXPECT_GE(bm->Size(), bitmap_size);
     bm->FreeRange(0, bitmap_size);
@@ -217,6 +284,8 @@ TEST(bitmap, get_free_index) {
     }
 
     delete (bm);
+
+    Recov_EndTrans(0);
 }
 
 static void check_range(bitmap* bm, int start, int len, int value) {
@@ -230,9 +299,15 @@ static void check_range(bitmap* bm, int start, int len, int value) {
 
 TEST(bitmap, ranges_cases) {
     int16_t bitmap_size = 333; // Simply need an unaligned size
-    bitmap * ones = new (0) bitmap(bitmap_size, 0);
-    bitmap * zeros = new (0) bitmap(bitmap_size, 0);
-    bitmap * test_bm = new (0) bitmap(bitmap_size, 0);
+    int recoverable_1 = rand() & 0x1;
+    int recoverable_2 = rand() & 0x1;
+    int recoverable_3 = rand() & 0x1;
+
+    Recov_BeginTrans();
+
+    bitmap * ones = new (recoverable_1) bitmap(bitmap_size, recoverable_1);
+    bitmap * zeros = new (recoverable_2) bitmap(bitmap_size, recoverable_2);
+    bitmap * test_bm = new (recoverable_3) bitmap(bitmap_size, recoverable_3);
     int start = 0;
     int len = 0;
 
@@ -370,6 +445,8 @@ TEST(bitmap, ranges_cases) {
     delete (zeros);
     delete (ones);
     delete (test_bm);
+
+    Recov_EndTrans(0);
 }
 
 }  // namespace

--- a/test-src/unit/util/u_test_rvm.cc
+++ b/test-src/unit/util/u_test_rvm.cc
@@ -16,6 +16,7 @@ listed in the file CREDITS.
 
 #*/
 /* system */
+#include <stdint.h>
 
 /* external */
 #include <gtest/gtest.h>
@@ -47,7 +48,7 @@ TEST(test_rvm, DISABLED_reinit) {
 }
 
 TEST(test_rvm, alloc) {
-    void * test_alloc = nullptr;
+    void * test_alloc = NULL;
 
     Recov_BeginTrans();
 

--- a/test-src/unit/util/u_test_rvm.cc
+++ b/test-src/unit/util/u_test_rvm.cc
@@ -1,0 +1,62 @@
+/* BLURB gpl
+
+                           Coda File System
+                              Release 7
+
+          Copyright (c) 1987-2018 Carnegie Mellon University
+                  Additional copyrights listed below
+
+This  code  is  distributed "AS IS" without warranty of any kind under
+the terms of the GNU General Public Licence Version 2, as shown in the
+file  LICENSE.  The  technical and financial  contributors to Coda are
+listed in the file CREDITS.
+
+                        Additional copyrights
+                           none currently
+
+#*/
+/* system */
+
+/* external */
+#include <gtest/gtest.h>
+
+/* from test-src */
+#include <test/rvm/rvm.h>
+#include <test/rvm/recov.h>
+
+namespace {
+
+// test_rvm.
+
+// Reinitialization of rvm is NOT supported
+TEST(test_rvm, init_destroy) {
+}
+
+// Reinitialization of rvm is NOT supported
+TEST(test_rvm, DISABLED_reinit) {
+    struct rvm_config config;
+    INIT_RVM_CONFIG(config)
+
+    RVMInit(config);
+    RVMDestroy(config);
+
+    INIT_RVM_CONFIG(config);
+
+    RVMInit(config);
+    RVMDestroy(config);
+}
+
+TEST(test_rvm, alloc) {
+    void * test_alloc = nullptr;
+
+    Recov_BeginTrans();
+
+    test_alloc = rvmlib_rec_malloc(sizeof(uint32_t));
+    EXPECT_TRUE(test_alloc);
+
+    rvmlib_rec_free(test_alloc);
+
+    Recov_EndTrans(0);
+}
+
+}  // namespace

--- a/test-src/unit/venus/Makefile.am
+++ b/test-src/unit/venus/Makefile.am
@@ -1,0 +1,35 @@
+## Process this file with automake to produce Makefile.in
+check_PROGRAMS = unittest
+
+# Add unittest and venus sources
+unittest_SOURCES = venus_symbols.cc u_cachefile.cc u_cachechunk.cc
+
+GTEST_DIR = $(top_builddir)/external-src/googletest/googletest
+
+unittest_LDADD = $(top_builddir)/test-src/unit/.libs/libmain_test.la \
+             $(top_builddir)/coda-src/venus/.libs/libvenus.la \
+             $(GTEST_DIR)/lib/libgtest.la
+
+AM_CPPFLAGS = $(RVM_RPC2_CFLAGS) -DVENUS -DTIMING -DVENUSDEBUG \
+              -I$(top_srcdir)/test-src/unit/include \
+              -I$(top_srcdir)/lib-src/base \
+              -I$(top_srcdir)/coda-src \
+              -I$(top_srcdir)/coda-src/util \
+              -I$(top_builddir)/coda-src \
+              -I$(top_builddir)/coda-src/vicedep \
+              -I$(top_builddir)/coda-src/vv \
+              -I$(top_builddir)/coda-src/dir \
+              -I$(top_builddir)/coda-src/kerndep \
+              -I$(top_srcdir)/coda-src/venus \
+              -I$(top_builddir)/coda-src/auth2 \
+              -I$(top_builddir)/coda-src/lka \
+              -I$(top_builddir)/coda-src/vol \
+              -I$(top_builddir)/coda-src/al \
+              -I$(top_builddir)/coda-src/librepair \
+              -I$(GTEST_DIR)/include
+
+check-local: unittest 
+	@LIBTOOL_PREFIX@ ./unittest @GTEST_FLAGS@ 
+
+memcheck: unittest
+	@LIBTOOL_PREFIX@ @VALGRIND@ ./unittest @GTEST_FLAGS@ 

--- a/test-src/unit/venus/u_cachechunk.cc
+++ b/test-src/unit/venus/u_cachechunk.cc
@@ -1,0 +1,89 @@
+/* BLURB gpl
+
+                           Coda File System
+                              Release 7
+
+          Copyright (c) 1987-2018 Carnegie Mellon University
+                  Additional copyrights listed below
+
+This  code  is  distributed "AS IS" without warranty of any kind under
+the terms of the GNU General Public Licence Version 2, as shown in the
+file  LICENSE.  The  technical and financial  contributors to Coda are
+listed in the file CREDITS.
+
+                        Additional copyrights
+                           none currently
+
+#*/
+/* system */
+#include <sys/stat.h>
+
+/* external */
+#include <gtest/gtest.h>
+
+/* from coda-src */
+#include <venus/fso_cachefile.h>
+
+/* from test-src */
+#include <test/rvm/rvm.h>
+
+namespace {
+
+// cachechunk.
+TEST(cachechunk, construct) {
+    int start = rand() & 0x7FF;
+    int len = rand() & 0x7F;
+    char name[13];
+    struct stat stat_b;
+    CacheChunk * cc = new CacheChunk(start, len);
+
+    EXPECT_EQ(cc->GetLength(), len);
+    EXPECT_EQ(cc->GetStart(), start);
+    EXPECT_TRUE(cc->isValid());
+
+    delete cc;
+
+    cc = new CacheChunk();
+    EXPECT_FALSE(cc->isValid());
+
+    delete cc;
+}
+
+TEST(cachechunk, list) {
+    int list_len = rand() & 0x3F;
+    int * start = new int[list_len];
+    int * len = new int[list_len];
+    dlist cachechunk_list;
+    CacheChunk * cc = NULL;
+
+    /* Create a list with random cachechunks */
+    for (int i = 0;  i < list_len; i++) {
+        start[i] =  rand() & 0x7FF;
+        len[i] =  rand() & 0x7F;
+
+        cachechunk_list.insert((dlink *) new CacheChunk(start[i], len[i]));
+    }
+
+    EXPECT_EQ(list_len, cachechunk_list.count());
+
+    /* Check the elements in the list */
+    for (int i = 0;  i < list_len; i++) {
+        cc = (CacheChunk *) cachechunk_list.last();
+
+        EXPECT_EQ(start[i], cc->GetStart());
+        EXPECT_EQ(len[i], cc->GetLength());
+        EXPECT_TRUE(cc->isValid());
+
+        cachechunk_list.remove((dlink *) cc);
+
+        EXPECT_EQ(list_len - 1 - i, cachechunk_list.count());
+
+        delete cc;
+    }
+
+    delete [] start;
+    delete [] len;
+
+}
+
+}  // namespace

--- a/test-src/unit/venus/u_cachefile.cc
+++ b/test-src/unit/venus/u_cachefile.cc
@@ -1,0 +1,125 @@
+/* BLURB gpl
+
+                           Coda File System
+                              Release 7
+
+          Copyright (c) 1987-2018 Carnegie Mellon University
+                  Additional copyrights listed below
+
+This  code  is  distributed "AS IS" without warranty of any kind under
+the terms of the GNU General Public Licence Version 2, as shown in the
+file  LICENSE.  The  technical and financial  contributors to Coda are
+listed in the file CREDITS.
+
+                        Additional copyrights
+                           none currently
+
+#*/
+/* system */
+#include <sys/stat.h>
+
+/* external */
+#include <gtest/gtest.h>
+
+/* from coda-src */
+#include <venus/fso_cachefile.h>
+
+/* from test-src */
+#include <test/rvm/rvm.h>
+
+namespace {
+
+void get_container_file_path(int i, char name[13]) {
+    sprintf(name, "%02X/%02X/%02X/%02X",
+           (i>>24) & 0xff, (i>>16) & 0xff, (i>>8) & 0xff, i & 0xff);
+}
+
+void EXPECT_FILE_EXISTS(char name[13], bool exists) {
+    struct stat stat_b;
+
+    if (exists) {
+        EXPECT_FALSE(stat(name, &stat_b)) << "File " << name << " doesn't exists";
+    } else {
+        EXPECT_TRUE(stat(name, &stat_b)) << "File " << name << " exists";
+    }
+        
+}
+
+// cachefile.
+TEST(cachefile, construct) {
+    int idx = rand() & 0x7FF;
+    char name[13];
+    struct stat stat_b;
+    CacheFile * cf = new CacheFile(idx, 0);
+
+    get_container_file_path(idx, name);
+
+    EXPECT_FILE_EXISTS(name, false);
+
+    delete(cf);
+
+    EXPECT_FILE_EXISTS(name, false);
+}
+
+TEST(cachefile, create) {
+    int idx = rand() & 0x7FF;
+    int size = rand() & 0x7FF;
+    CacheFile * cf = new CacheFile(idx, 0);
+    char name[13];
+    struct stat stat_b;
+
+    get_container_file_path(idx, name);
+
+    cf->Create(size);
+    EXPECT_FILE_EXISTS(name, true);
+    stat(name, &stat_b);
+    EXPECT_EQ(stat_b.st_size, size);
+    EXPECT_EQ(stat_b.st_blocks, 0);
+
+
+    cf->Truncate(0);
+
+    EXPECT_FILE_EXISTS(name, true);
+    stat(name, &stat_b);
+    EXPECT_EQ(stat_b.st_size, 0);
+    EXPECT_EQ(stat_b.st_blocks, 0);
+
+    delete(cf);
+
+    EXPECT_FILE_EXISTS(name, false);
+}
+
+TEST(cachefile, create_ref_cnt) {
+    int idx = rand() & 0x7FF;
+    int size = rand() & 0x7FF;
+    CacheFile * cf = new CacheFile(idx, 0);
+    char name[13];
+    struct stat stat_b;
+
+    get_container_file_path(idx, name);
+
+    cf->Create(size);
+    EXPECT_FILE_EXISTS(name, true);
+    stat(name, &stat_b);
+    EXPECT_EQ(stat_b.st_size, size);
+    EXPECT_EQ(stat_b.st_blocks, 0);
+
+    cf->IncRef();
+    cf->IncRef();
+    cf->IncRef();
+
+    EXPECT_FILE_EXISTS(name, true);
+
+    cf->DecRef();
+    cf->DecRef();
+    cf->DecRef();
+    cf->DecRef();
+
+    EXPECT_FILE_EXISTS(name, false);
+
+    delete(cf);
+
+    EXPECT_FILE_EXISTS(name, false);
+}
+
+}  // namespace

--- a/test-src/unit/venus/venus_symbols.cc
+++ b/test-src/unit/venus/venus_symbols.cc
@@ -1,0 +1,126 @@
+
+/* BLURB gpl
+
+                           Coda File System
+                              Release 7
+
+          Copyright (c) 1987-2018 Carnegie Mellon University
+                  Additional copyrights listed below
+
+This  code  is  distributed "AS IS" without warranty of any kind under
+the terms of the GNU General Public Licence Version 2, as shown in the
+file  LICENSE.  The  technical and financial  contributors to Coda are
+listed in the file CREDITS.
+
+                        Additional copyrights
+                           none currently
+
+#*/
+/* system */
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+/* venus */
+#include <venus/venusfid.h>
+#include <venus/vproc.h>
+
+/* This file holds the symbols from venus.cc needed for enable 
+   the build of the tests. */
+
+#define UNSET_PRIMARYUSER 0 /* primary user of this machine */
+
+/* Some helpers to add fd/callbacks to the inner select loop */
+struct mux_cb_entry {
+    struct mux_cb_entry *next;
+    int fd;
+    void (*cb)(int fd, void *udata);
+    void *udata;
+};
+static struct mux_cb_entry *_MUX_CBEs;
+
+uid_t PrimaryUser = UNSET_PRIMARYUSER;
+
+/* Logging/Console */
+const char *consoleFile = "/usr/coda/etc/console";
+const char *VenusLogFile = "/tmp/test";
+
+/* Process */
+int parent_fd = -1;
+vproc *Main =  NULL;
+int nofork = 1;
+
+/* Cache */
+const char *CachePrefix = "";
+unsigned int CacheBlocks = 100000;
+
+/* Mariner */
+const char *MarinerSocketPath = "/usr/coda/spool/mariner";
+int masquerade_port = 0;
+#if defined(HAVE_SYS_UN_H) && !defined(__CYGWIN32__)
+int mariner_tcp_enable = 0;
+#else
+int mariner_tcp_enable = 1;
+#endif
+
+/* ASR */
+pid_t ASRpid;
+VenusFid ASRfid;
+uid_t ASRuid;
+const char *ASRLauncherFile = NULL;
+const char *ASRPolicyFile = NULL;
+
+/* Other */
+int detect_reintegration_retry = 0;
+int CleanShutDown = 0;
+const char *SpoolDir = "/usr/coda/spool";
+const char *venusRoot = "/coda";
+int PiggyValidations = 15;
+int plan9server_enabled = 0;
+int option_isr = 0;
+const char *kernDevice = "/dev/cfs0";
+int SearchForNOreFind = 0; 
+int redzone_limit = -1;
+int yellowzone_limit = -1;
+VenusFid rootfid;
+
+/* Helper to add a file descriptor with callback to main select loop.
+ *
+ * Call with cb == NULL to remove existing callback.
+ * cb is called with fd == -1 when an existing callback is removed or updated.
+ */
+void MUX_add_callback(int fd, void (*cb)(int fd, void *udata), void *udata)
+{
+    struct mux_cb_entry *cbe = _MUX_CBEs, *prev = NULL;
+
+    for (; cbe; cbe = cbe->next)
+    {
+        if (cbe->fd == fd) {
+            /* remove old callback entry */
+            if (prev)
+                prev->next = cbe->next;
+            else
+                _MUX_CBEs = cbe->next;
+
+            /* allow cb to free udata resources */
+            cbe->cb(-1, cbe->udata);
+
+            free(cbe);
+            break;
+        }
+        prev = cbe;
+    }
+    /* if we are not adding a new callback, we're done */
+    if (cb == NULL)
+        return;
+
+    cbe = (struct mux_cb_entry *)malloc(sizeof(*cbe));
+    assert(cbe != NULL);
+
+    cbe->fd = fd;
+    cbe->cb = cb;
+    cbe->udata = udata;
+
+    cbe->next = _MUX_CBEs;
+    _MUX_CBEs = cbe;
+}


### PR DESCRIPTION
* Allows testing of some venus sub-components that don't interact/depend on daemons or a running coda sever 
* Add Cachechunk unit test
* Add some Cachefile unit test
* Add RVM support for unit testing
* Refactor unittests building. Now there will be a `unittest` binary for every `test-src/unit` subdirectory (except for lib).
* Fix memory leaks found in RVM and LWP libraries
* Add RVM support to `bitmap`'s unit tests
* Add RVM unit tests
* Add unit test running to travis