### PR TITLE
Fix callbacks for non-replicated volumes

### DIFF
--- a/coda-src/venus/fso1.cc
+++ b/coda-src/venus/fso1.cc
@@ -880,7 +880,7 @@ int fsobj::IsValid(int rcrights)
 
     /* Replicated objects must be considered valid when we are either
      * unreachable or reachable and the object is dirty. */
-    if (vol->IsReplicated()) {
+    if (vol->IsReplicated() || vol->IsNonReplicated()) {
         if (vol->IsUnreachable())
             return 1;
         if (vol->IsReachable() && flags.dirty)
@@ -895,7 +895,7 @@ int fsobj::IsValid(int rcrights)
 
     /* Now if we still have the volume callback, we can't lose.
      * also update VCB statistics -- valid due to VCB */
-    if (!vol->IsReplicated())
+    if (!(vol->IsReplicated() || vol->IsNonReplicated()))
         return 0;
 
     repvol *vp = (repvol *)vol;

--- a/coda-src/venus/fso1.cc
+++ b/coda-src/venus/fso1.cc
@@ -2612,6 +2612,7 @@ void fsobj::UpdateVastroFlag(uid_t uid)
             goto PutAll;
 
         s = c->srv;
+        s->GetRef();
 
         if (!s->fetchpartial_support) {
             flags.vastro = 0x0;

--- a/coda-src/venus/fso1.cc
+++ b/coda-src/venus/fso1.cc
@@ -898,7 +898,7 @@ int fsobj::IsValid(int rcrights)
     if (!(vol->IsReplicated() || vol->IsNonReplicated()))
         return 0;
 
-    repvol *vp = (repvol *)vol;
+    reintvol *vp = (reintvol *)vol;
     if (vp->HaveCallBack()) {
         vp->VCBHits++;
         return 1;

--- a/coda-src/venus/fso1.cc
+++ b/coda-src/venus/fso1.cc
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2018 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -474,7 +474,7 @@ void fsobj::Recover()
         goto FailSafe;
     }
 
-    if (!vol->IsReplicated() && !IsLocalObj()) {
+    if (!vol->IsReadWrite() && !IsLocalObj()) {
         LOG(0, ("fsobj::Recover: (%s) is probably in a backup volume\n",
                 FID_(&fid)));
         goto Failure;
@@ -845,7 +845,7 @@ int fsobj::CheckRcRights(int rights)
 
 void fsobj::SetRcRights(int rights)
 {
-    if (!vol->IsReplicated() || IsFake())
+    if (!vol->IsReadWrite() || IsFake())
         return;
 
     if (!HAVEALLDATA(this))
@@ -2661,9 +2661,10 @@ void fsobj::print(int fdes)
     }
     fdprint(
         fdes,
-        "\tvoltype = [%d %d %d], fake = %d, fetching = %d local = %d, expanded = %d\n",
+        "\tvoltype = [%d %d %d %d], fake = %d, fetching = %d local = %d, expanded = %d\n",
         vol->IsBackup(), vol->IsReplicated(), vol->IsReadWriteReplica(),
-        flags.fake, flags.fetching, flags.local, flags.expanded);
+        vol->IsReadWrite(), flags.fake, flags.fetching, flags.local,
+        flags.expanded);
     fdprint(
         fdes,
         "\trep = %d, data = %d, owrite = %d, dirty = %d, shadow = %d ckmtpt\n",

--- a/coda-src/venus/fso1.cc
+++ b/coda-src/venus/fso1.cc
@@ -880,7 +880,7 @@ int fsobj::IsValid(int rcrights)
 
     /* Replicated objects must be considered valid when we are either
      * unreachable or reachable and the object is dirty. */
-    if (vol->IsReplicated() || vol->IsNonReplicated()) {
+    if (vol->IsReadWrite()) {
         if (vol->IsUnreachable())
             return 1;
         if (vol->IsReachable() && flags.dirty)
@@ -895,7 +895,7 @@ int fsobj::IsValid(int rcrights)
 
     /* Now if we still have the volume callback, we can't lose.
      * also update VCB statistics -- valid due to VCB */
-    if (!(vol->IsReplicated() || vol->IsNonReplicated()))
+    if (!vol->IsReadWrite())
         return 0;
 
     reintvol *vp = (reintvol *)vol;

--- a/coda-src/venus/fso_cfscalls0.cc
+++ b/coda-src/venus/fso_cfscalls0.cc
@@ -767,10 +767,10 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                 MULTI_START_MESSAGE(ViceValidateAttrsPlusSHA_OP);
                 code = (int)MRPC_MakeMulti(
                     ViceValidateAttrsPlusSHA_OP, ViceValidateAttrsPlusSHA_PTR,
-                    rpc_common.nservers, rpc_common.handles, rpc_common.retcodes,
-                    rpc_common.MIp, 0, 0, rpc_common.ph, MakeViceFid(&fid),
-                    statusvar_ptrs, myshavar_ptrs, numPiggyFids, FAVs,
-                    VFlagvar_ptrs, &PiggyBS);
+                    rpc_common.nservers, rpc_common.handles,
+                    rpc_common.retcodes, rpc_common.MIp, 0, 0, rpc_common.ph,
+                    MakeViceFid(&fid), statusvar_ptrs, myshavar_ptrs,
+                    numPiggyFids, FAVs, VFlagvar_ptrs, &PiggyBS);
                 MULTI_END_MESSAGE(ViceValidateAttrsPlusSHA_OP);
                 CFSOP_POSTLUDE("fetch::ValidateAttrsPlusSHA done\n");
 
@@ -910,12 +910,11 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                     */
 
                     MULTI_START_MESSAGE(ViceGetACL_OP);
-                    code = (int)MRPC_MakeMulti(ViceGetACL_OP, ViceGetACL_PTR,
-                                               rpc_common.nservers, rpc_common.handles,
-                                               rpc_common.retcodes, rpc_common.MIp, 0,
-                                               0, MakeViceFid(&fid), inconok,
-                                               aclvar_ptrs, statusvar_ptrs,
-                                               rpc_common.ph, &PiggyBS);
+                    code = (int)MRPC_MakeMulti(
+                        ViceGetACL_OP, ViceGetACL_PTR, rpc_common.nservers,
+                        rpc_common.handles, rpc_common.retcodes, rpc_common.MIp,
+                        0, 0, MakeViceFid(&fid), inconok, aclvar_ptrs,
+                        statusvar_ptrs, rpc_common.ph, &PiggyBS);
                     MULTI_END_MESSAGE(ViceGetACL_OP);
                     CFSOP_POSTLUDE(post_str);
 
@@ -934,9 +933,10 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                     MULTI_START_MESSAGE(ViceGetAttrPlusSHA_OP);
                     code = (int)MRPC_MakeMulti(
                         ViceGetAttrPlusSHA_OP, ViceGetAttrPlusSHA_PTR,
-                        rpc_common.nservers, rpc_common.handles, rpc_common.retcodes,
-                        rpc_common.MIp, 0, 0, MakeViceFid(&fid), inconok,
-                        statusvar_ptrs, myshavar_ptrs, rpc_common.ph, &PiggyBS);
+                        rpc_common.nservers, rpc_common.handles,
+                        rpc_common.retcodes, rpc_common.MIp, 0, 0,
+                        MakeViceFid(&fid), inconok, statusvar_ptrs,
+                        myshavar_ptrs, rpc_common.ph, &PiggyBS);
                     MULTI_END_MESSAGE(ViceGetAttrPlusSHA_OP);
                     CFSOP_POSTLUDE(post_str);
 

--- a/coda-src/venus/fso_cfscalls0.cc
+++ b/coda-src/venus/fso_cfscalls0.cc
@@ -1672,9 +1672,6 @@ int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
         if (code != 0)
             goto NonRepExit;
 
-        /* The COP1 call. */
-        cbtemp = cbbreaks;
-
         /* Make the RPC call. */
         CFSOP_PRELUDE("store::setacl %s\n", comp, fid);
         UNI_START_MESSAGE(ViceSetACL_OP);

--- a/coda-src/venus/fso_cfscalls0.cc
+++ b/coda-src/venus/fso_cfscalls0.cc
@@ -614,7 +614,7 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
     const char *post_str = getacl ? "fetch::GetACL done\n" :
                                     "fetch::GetAttr done\n";
     int i = 0;
-    struct RPC2_common_params rpc_common;
+    struct MRPC_common_params rpc_common;
     struct in_addr ph_addr;
 
     /*
@@ -1484,7 +1484,7 @@ int fsobj::SetAttr(struct coda_vattr *vap, uid_t uid)
 
 int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
 {
-    struct RPC2_common_params rpc_common;
+    struct MRPC_common_params rpc_common;
     struct in_addr ph_addr;
     ViceVersionVector UpdateSet;
     ViceStoreId sid;

--- a/coda-src/venus/fso_cfscalls0.cc
+++ b/coda-src/venus/fso_cfscalls0.cc
@@ -602,6 +602,31 @@ int fsobj::Fetch(uid_t uid, uint64_t pos, int64_t count)
 
 int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
 {
+    repvol *vp           = (repvol *)vol;
+    connent *c           = NULL;
+    mgrpent *m           = 0;
+    int code             = 0;
+    int ret_code         = 0;
+    int getacl           = (acl != 0);
+    int inconok          = !vol->IsReplicated();
+    const char *prel_str = getacl ? "fetch::GetACL %s\n" :
+                                    "fetch::GetAttr %s\n";
+    const char *post_str = getacl ? "fetch::GetACL done\n" :
+                                    "fetch::GetAttr done\n";
+    int i = 0;
+    struct RPC2_common_params rpc_common;
+    struct in_addr ph_addr;
+
+    /*
+     * these fields are for tracking vcb acquisition.  Since we
+     * use vcbs on replicated volumes only, the data collection
+     * goes in this branch of GetAttr.
+     */
+    int nchecked = 0, nfailed = 0;
+    long cbtemp = cbbreaks;
+    char val_prel_str[256];
+    int asy_resolve = 0;
+
     LOG(10, ("fsobj::GetAttr: (%s), uid = %d\n", GetComp(), uid));
 
     CODA_ASSERT(!IsLocalObj());
@@ -611,14 +636,6 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
         /* Better not be disconnected or dirty! */
         FSO_ASSERT(this, (REACHABLE(this) && !DIRTY(this)));
     }
-
-    int code             = 0;
-    int getacl           = (acl != 0);
-    int inconok          = !vol->IsReplicated();
-    const char *prel_str = getacl ? "fetch::GetACL %s\n" :
-                                    "fetch::GetAttr %s\n";
-    const char *post_str = getacl ? "fetch::GetACL done\n" :
-                                    "fetch::GetAttr done\n";
 
     /* Dummy argument for ACL */
     RPC2_BoundedBS dummybs;
@@ -642,42 +659,43 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
     PiggyBS.SeqLen  = 0;
     PiggyBS.SeqBody = (RPC2_ByteSeq)PiggyData;
 
-    if (vol->IsReplicated()) {
-        mgrpent *m      = 0;
-        int asy_resolve = 0;
-        repvol *vp      = (repvol *)vol;
+    if (vol->IsReadWrite()) {
+        cbtemp = cbbreaks;
 
-        /*
-	 * these fields are for tracking vcb acquisition.  Since we
-	 * use vcbs on replicated volumes only, the data collection
-	 * goes in this branch of GetAttr.
-	 */
-        int nchecked = 0, nfailed = 0;
-        long cbtemp = cbbreaks;
-        char val_prel_str[256];
-
-        /* Acquire an Mgroup. */
-        code = vp->GetMgrp(&m, uid, (PIGGYCOP2 ? &PiggyBS : 0));
+        code = vp->GetConn(&c, uid, &m, &rpc_common.ph_ix, &ph_addr);
         if (code != 0)
             goto RepExit;
 
-        nchecked++; /* we're going to check at least the primary fid */
-        int i;
-        {
-            /* Make multiple copies of the IN/OUT and OUT parameters. */
-            int ph_ix;
-            unsigned long ph;
-            ph = ntohl(m->GetPrimaryHost(&ph_ix)->s_addr);
+        rpc_common.ph = ntohl(ph_addr.s_addr);
 
+        if (vol->IsReplicated()) {
+            rpc_common.nservers = VSG_MEMBERS;
+            rpc_common.hosts    = m->rocc.hosts;
+            rpc_common.retcodes = m->rocc.retcodes;
+            rpc_common.handles  = m->rocc.handles;
+            rpc_common.MIp      = m->rocc.MIp;
+
+        } else { // Non-replicated
+
+            rpc_common.nservers = 1;
+            rpc_common.hosts    = &ph_addr;
+            rpc_common.retcodes = &ret_code;
+            rpc_common.handles  = &c->connid;
+            rpc_common.MIp      = 0;
+        }
+
+        nchecked++; /* we're going to check at least the primary fid */
+        {
             /* unneccesary in validation case but it beats duplicating code. */
             if (acl->MaxSeqLen > VENUS_MAXBSLEN)
                 CHOKE("fsobj::GetAttr: BS len too large (%d)", acl->MaxSeqLen);
             ARG_MARSHALL_BS(IN_OUT_MODE, RPC2_BoundedBS, aclvar, *acl,
-                            VSG_MEMBERS, VENUS_MAXBSLEN);
-            ARG_MARSHALL(OUT_MODE, ViceStatus, statusvar, status, VSG_MEMBERS);
+                            rpc_common.nservers, VENUS_MAXBSLEN);
+            ARG_MARSHALL(OUT_MODE, ViceStatus, statusvar, status,
+                         rpc_common.nservers);
 
             ARG_MARSHALL_BS(OUT_MODE, RPC2_BoundedBS, myshavar, mysha,
-                            VSG_MEMBERS, SHA_DIGEST_LENGTH);
+                            rpc_common.nservers, SHA_DIGEST_LENGTH);
 
             if (HAVESTATUS(this) && !getacl) {
                 ViceFidAndVV FAVs[MAX_PIGGY_VALIDATIONS];
@@ -711,7 +729,7 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                         continue;
 
                     /* paranoia check */
-                    FSO_ASSERT(this, f->vol->IsReplicated());
+                    FSO_ASSERT(this, f->vol->IsReadWrite());
 
                     LOG(1000,
                         ("fsobj::GetAttr: packing piggy fid (%s) comp = %s\n",
@@ -726,11 +744,11 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                 (void)qsort((char *)FAVs, numPiggyFids, sizeof(ViceFidAndVV),
                             (int (*)(const void *, const void *))FAV_Compare);
 
-                /*
-		 * another OUT parameter. We don't use an array here
-		 * because each char would be embedded in a struct that
-		 * would be longword aligned. Ugh.
-		 */
+                /* 
+                 * another OUT parameter. We don't use an array here
+                 * because each char would be embedded in a struct that
+                 * would be longword aligned. Ugh.
+                 */
                 char VFlags[MAX_PIGGY_VALIDATIONS];
                 RPC2_BoundedBS VFlagBS;
 
@@ -739,7 +757,7 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                 VFlagBS.SeqBody   = (RPC2_ByteSeq)VFlags;
 
                 ARG_MARSHALL_BS(IN_OUT_MODE, RPC2_BoundedBS, VFlagvar, VFlagBS,
-                                VSG_MEMBERS, MAX_PIGGY_VALIDATIONS);
+                                rpc_common.nservers, MAX_PIGGY_VALIDATIONS);
 
                 /* make the RPC */
                 sprintf(val_prel_str,
@@ -749,37 +767,43 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                 MULTI_START_MESSAGE(ViceValidateAttrsPlusSHA_OP);
                 code = (int)MRPC_MakeMulti(
                     ViceValidateAttrsPlusSHA_OP, ViceValidateAttrsPlusSHA_PTR,
-                    VSG_MEMBERS, m->rocc.handles, m->rocc.retcodes, m->rocc.MIp,
-                    0, 0, ph, MakeViceFid(&fid), statusvar_ptrs, myshavar_ptrs,
-                    numPiggyFids, FAVs, VFlagvar_ptrs, &PiggyBS);
+                    rpc_common.nservers, rpc_common.handles, rpc_common.retcodes,
+                    rpc_common.MIp, 0, 0, rpc_common.ph, MakeViceFid(&fid),
+                    statusvar_ptrs, myshavar_ptrs, numPiggyFids, FAVs,
+                    VFlagvar_ptrs, &PiggyBS);
                 MULTI_END_MESSAGE(ViceValidateAttrsPlusSHA_OP);
                 CFSOP_POSTLUDE("fetch::ValidateAttrsPlusSHA done\n");
 
                 /* Collate */
-                code = vp->Collate_NonMutating(m, code);
+                if (vp->IsReplicated()) {
+                    code = vp->Collate_NonMutating(m, code);
+                } else {
+                    code = vp->Collate(c, code);
+                }
+
                 MULTI_RECORD_STATS(ViceValidateAttrsPlusSHA_OP);
 
                 if (code == EASYRESOLVE) {
                     asy_resolve = 1;
                     code        = 0;
                 } else if (code == 0 || code == ERETRY) {
-                    /*
-		     * collate flags from vsg members. even if the return
-		     * is ERETRY we can (and should) grab the flags.
-		     */
+                    /* 
+                     * collate flags from vsg members. even if the return
+                     * is ERETRY we can (and should) grab the flags.
+                     */
                     int numVFlags = 0;
 
-                    for (i = 0; i < VSG_MEMBERS; i++)
-                        if (m->rocc.hosts[i].s_addr != 0) {
+                    for (i = 0; i < rpc_common.nservers; i++)
+                        if (rpc_common.hosts[i].s_addr != 0) {
                             if (numVFlags == 0) {
                                 /* unset, copy in one response */
                                 ARG_UNMARSHALL_BS(VFlagvar, VFlagBS, i);
                                 numVFlags = (unsigned)VFlagBS.SeqLen;
                             } else {
-                                /*
-				 * "and" in results from other servers. 
-				 * Remember that VFlagBS.SeqBody == VFlags.
-				 */
+                                /* 
+                                 * "and" in results from other servers. 
+                                 * Remember that VFlagBS.SeqBody == VFlags.
+                                 */
                                 for (int j = 0; j < numPiggyFids; j++)
                                     VFlags[j] &= VFlagvar_bufs[i].SeqBody[j];
                             }
@@ -790,15 +814,15 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                          GetComp(), numPiggyFids, numVFlags));
 
                     nchecked += numPiggyFids;
-                    /*
-		     * now set status of piggybacked objects 
-		     */
+                    /* 
+                     * now set status of piggybacked objects 
+                     */
                     for (i = 0; i < numVFlags; i++) {
-                        /*
-			 * lookup this object. It may have been flushed and
-			 * reincarnated as a runt in the while we were out,
-			 * so we check status again.
-			 */
+                        /* 
+                         * lookup this object. It may have been flushed and
+                         * reincarnated as a runt in the while we were out,
+                         * so we check status again.
+                         */
                         fsobj *pobj;
                         VenusFid vf;
                         MakeVenusFid(&vf, vol->GetRealmId(), &FAVs[i].Fid);
@@ -810,7 +834,7 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                                     ("fsobj::GetAttr: ValidateAttrs (%s), fid (%s) valid\n",
                                      pobj->GetComp(), FID_(&FAVs[i].Fid)));
                                 /* callbacks broken during validation make
-				 * any positive return codes suspect. */
+                                 * any positive return codes suspect. */
                                 if (cbtemp != cbbreaks)
                                     continue;
 
@@ -818,10 +842,10 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                                     pobj->SetRcRights(RC_STATUS);
                                 else
                                     pobj->SetRcRights(RC_STATUS | RC_DATA);
-                                /*
-				 * if the object matched, the access rights 
-				 * cached for this object are still good.
-				 */
+                                /* 
+                                 * if the object matched, the access rights 
+                                 * cached for this object are still good.
+                                 */
                                 if (pobj->IsDir()) {
                                     pobj->PromoteAcRights(ANYUSER_UID);
                                     pobj->PromoteAcRights(uid);
@@ -843,17 +867,17 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                                     pobj->Demote();
 
                                 nfailed++;
-                                /*
-				 * If we have data, it is stale and must be
-				 * discarded, unless someone is writing or
-				 * executing it, or it is a fake directory.
-				 * In that case, we wait and rely on the
-				 * destructor to discard the data.
-				 *
-				 * We don't restart from the beginning,
-				 * since the validation of piggybacked fids
-				 * is a side-effect.
-				 */
+                                /* 
+                                 * If we have data, it is stale and must be
+                                 * discarded, unless someone is writing or
+                                 * executing it, or it is a fake directory.
+                                 * In that case, we wait and rely on the
+                                 * destructor to discard the data.
+                                 *
+                                 * We don't restart from the beginning,
+                                 * since the validation of piggybacked fids
+                                 * is a side-effect.
+                                 */
                                 if (HAVEDATA(pobj) && !ACTIVE(pobj) &&
                                     !pobj->IsFakeDir() &&
                                     !pobj->IsExpandedDir() && !DIRTY(pobj)) {
@@ -883,21 +907,25 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                        Side note: ACL's only exist for directory objects, and
                        lookaside only works for file objects, so it really
                        shouldn't matter right now -JH.
-                     */
+                    */
 
                     MULTI_START_MESSAGE(ViceGetACL_OP);
                     code = (int)MRPC_MakeMulti(ViceGetACL_OP, ViceGetACL_PTR,
-                                               VSG_MEMBERS, m->rocc.handles,
-                                               m->rocc.retcodes, m->rocc.MIp, 0,
+                                               rpc_common.nservers, rpc_common.handles,
+                                               rpc_common.retcodes, rpc_common.MIp, 0,
                                                0, MakeViceFid(&fid), inconok,
-                                               aclvar_ptrs, statusvar_ptrs, ph,
-                                               &PiggyBS);
+                                               aclvar_ptrs, statusvar_ptrs,
+                                               rpc_common.ph, &PiggyBS);
                     MULTI_END_MESSAGE(ViceGetACL_OP);
                     CFSOP_POSTLUDE(post_str);
 
                     /* Collate responses from individual servers and decide
-		     * what to do next. */
-                    code = vp->Collate_NonMutating(m, code);
+                     * what to do next. */
+                    if (vp->IsReplicated()) {
+                        code = vp->Collate_NonMutating(m, code);
+                    } else {
+                        code = vp->Collate(c, code);
+                    }
                     MULTI_RECORD_STATS(ViceGetACL_OP);
                 } else {
                     /* get attributes from replicated servers */
@@ -906,15 +934,19 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                     MULTI_START_MESSAGE(ViceGetAttrPlusSHA_OP);
                     code = (int)MRPC_MakeMulti(
                         ViceGetAttrPlusSHA_OP, ViceGetAttrPlusSHA_PTR,
-                        VSG_MEMBERS, m->rocc.handles, m->rocc.retcodes,
-                        m->rocc.MIp, 0, 0, MakeViceFid(&fid), inconok,
-                        statusvar_ptrs, myshavar_ptrs, ph, &PiggyBS);
+                        rpc_common.nservers, rpc_common.handles, rpc_common.retcodes,
+                        rpc_common.MIp, 0, 0, MakeViceFid(&fid), inconok,
+                        statusvar_ptrs, myshavar_ptrs, rpc_common.ph, &PiggyBS);
                     MULTI_END_MESSAGE(ViceGetAttrPlusSHA_OP);
                     CFSOP_POSTLUDE(post_str);
 
                     /* Collate responses from individual servers and decide
                      * what to do next. */
-                    code = vp->Collate_NonMutating(m, code);
+                    if (vp->IsReplicated()) {
+                        code = vp->Collate_NonMutating(m, code);
+                    } else {
+                        code = vp->Collate(c, code);
+                    }
                     MULTI_RECORD_STATS(ViceGetAttrPlusSHA_OP);
                 }
 
@@ -928,33 +960,39 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
 
             /* common code for replicated case */
 
-            /* Finalize COP2 Piggybacking. */
-            if (PIGGYCOP2)
-                vp->ClearCOP2(&PiggyBS);
+            int dh_ix = -1;
 
-            /* Collect the OUT VVs in an array so that they can be checked. */
-            ViceVersionVector *vv_ptrs[VSG_MEMBERS];
-            for (int j = 0; j < VSG_MEMBERS; j++)
-                vv_ptrs[j] = &((statusvar_ptrs[j])->VV);
+            /* Finalize COP2 Piggybacking. There's no COP2 for non-replicated volumes */
+            if (vol->IsReplicated()) {
+                if (PIGGYCOP2)
+                    vp->ClearCOP2(&PiggyBS);
 
-            /* Check the version vectors for consistency. */
-            code = m->RVVCheck(vv_ptrs, (int)ISDIR(fid));
-            if (code == EASYRESOLVE) {
-                asy_resolve = 1;
-                code        = 0;
+                /* Collect the OUT VVs in an array so that they can be checked. */
+                ViceVersionVector *vv_ptrs[VSG_MEMBERS];
+                for (int j = 0; j < rpc_common.nservers; j++)
+                    vv_ptrs[j] = &((statusvar_ptrs[j])->VV);
+
+                /* Check the version vectors for consistency. */
+                code = m->RVVCheck(vv_ptrs, (int)ISDIR(fid));
+                if (code == EASYRESOLVE) {
+                    asy_resolve = 1;
+                    code        = 0;
+                }
+                if (code != 0)
+                    goto RepExit;
+
+                /* 
+                 * Compute the dominant host set.  
+                 * The index of a dominant host is returned as a side-effect. 
+                 */
+
+                dh_ix = -1;
+                code  = m->DHCheck(vv_ptrs, rpc_common.ph_ix, &dh_ix, 1);
+                if (code != 0)
+                    goto RepExit;
+            } else {
+                dh_ix = 0;
             }
-            if (code != 0)
-                goto RepExit;
-
-            /*
-	     * Compute the dominant host set.  
-	     * The index of a dominant host is returned as a side-effect. 
-	     */
-            int dh_ix;
-            dh_ix = -1;
-            code  = m->DHCheck(vv_ptrs, ph_ix, &dh_ix, 1);
-            if (code != 0)
-                goto RepExit;
 
             /* Manually compute the OUT parameters from the mgrpent::GetAttr() call! -JJK */
             if (getacl) {
@@ -1072,7 +1110,7 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                     f        = list_entry_plusplus(p, fsobj, vol_handle);
 
                     /* Kill is scary, so we make sure we keep an active
-			 * reference to the ->next object */
+                     * reference to the ->next object */
                     next = p->next;
                     if (next != &vol->fso_list) {
                         n = list_entry_plusplus(next, fsobj, vol_handle);
@@ -1098,16 +1136,15 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
         default:
             break;
         }
-    } else {
+    } else { // !IsReadWrite()
         /* Acquire a Connection. */
-        connent *c;
+        connent *c = NULL;
         volrep *vp = (volrep *)vol;
         code       = vp->GetConn(&c, uid);
         if (code != 0)
             goto NonRepExit;
 
         /* Make the RPC call. */
-        long cbtemp;
         cbtemp = cbbreaks;
         CFSOP_PRELUDE(prel_str, comp, fid);
         if (getacl) {

--- a/coda-src/venus/fso_cfscalls0.cc
+++ b/coda-src/venus/fso_cfscalls0.cc
@@ -1450,6 +1450,7 @@ int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
     LOG(10, ("fsobj::SetACL: (%s), uid = %d\n", GetComp(), uid));
 
     ViceVersionVector UpdateSet;
+    long cbtemp = 0;
 
     if (!REACHABLE(this))
         return ETIMEDOUT;
@@ -1510,7 +1511,6 @@ int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
             goto RepExit;
 
         /* The COP1 call. */
-        long cbtemp;
         cbtemp = cbbreaks;
 
         Recov_BeginTrans();
@@ -1541,7 +1541,6 @@ int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
             MULTI_END_MESSAGE(ViceSetACL_OP);
             CFSOP_POSTLUDE("store::setacl done\n");
 
-            free(OldVS.SeqBody);
             /* Collate responses from individual servers and decide what to
 	     * do next. */
             code = vp->Collate_COP1(m, code, &UpdateSet);
@@ -1606,6 +1605,11 @@ int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
         if (code != 0)
             goto NonRepExit;
 
+        vp->PackVS(1, &OldVS);
+
+        /* The COP1 call. */
+        cbtemp = cbbreaks;
+
         /* Make the RPC call. */
         CFSOP_PRELUDE("store::setacl %s\n", comp, fid);
         UNI_START_MESSAGE(ViceSetACL_OP);
@@ -1621,7 +1625,11 @@ int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
         if (code != 0)
             goto NonRepExit;
 
-        /* Non-replicated volumes stil use the first slot */
+        /* Update volume callback information */
+        if (cbtemp == cbbreaks)
+            vp->UpdateVCBInfo(VS, VCBStatus);
+
+        /* Non-replicated volumes still use the first slot */
         InitVV(&UpdateSet);
         if (vol->IsNonReplicated())
             (&(UpdateSet.Versions.Site0))[0] = 1;
@@ -1638,6 +1646,9 @@ int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
     /* Cached rights are suspect now! */
     if (code == 0)
         Demote();
+
+    if (OldVS.SeqBody)
+        free(OldVS.SeqBody);
 
     return (code);
 }

--- a/coda-src/venus/fso_cfscalls0.cc
+++ b/coda-src/venus/fso_cfscalls0.cc
@@ -22,7 +22,7 @@ listed in the file CREDITS.
  *
  *    ToDo:
  *       1. All mutating Vice calls should have the following IN arguments:
- *            NewSid, NewMutator (implicit from connection), NewMtime, 
+ *            NewSid, NewMutator (implicit from connection), NewMtime,
  *            OldVV and DataVersion (for each object), NewStatus (for each object)
  */
 
@@ -701,11 +701,11 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                 ViceFidAndVV FAVs[MAX_PIGGY_VALIDATIONS];
 
                 /*
-		 * pack piggyback fids and version vectors from this volume. 
+		 * pack piggyback fids and version vectors from this volume.
 		 * We exclude busy objects because if their validation fails,
 		 * they end up in the same state (demoted) that they are now.
-		 * A nice optimization would be to pack them highest priority 
-		 * first, from the priority queue. Unfortunately this may not 
+		 * A nice optimization would be to pack them highest priority
+		 * first, from the priority queue. Unfortunately this may not
 		 * result in the most efficient packing because only
 		 * _replaceable_ objects are in the priority queue (duh).
 		 * So others that need to be checked may be missed,
@@ -744,7 +744,7 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                 (void)qsort((char *)FAVs, numPiggyFids, sizeof(ViceFidAndVV),
                             (int (*)(const void *, const void *))FAV_Compare);
 
-                /* 
+                /*
                  * another OUT parameter. We don't use an array here
                  * because each char would be embedded in a struct that
                  * would be longword aligned. Ugh.
@@ -787,7 +787,7 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                     asy_resolve = 1;
                     code        = 0;
                 } else if (code == 0 || code == ERETRY) {
-                    /* 
+                    /*
                      * collate flags from vsg members. even if the return
                      * is ERETRY we can (and should) grab the flags.
                      */
@@ -800,8 +800,8 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                                 ARG_UNMARSHALL_BS(VFlagvar, VFlagBS, i);
                                 numVFlags = (unsigned)VFlagBS.SeqLen;
                             } else {
-                                /* 
-                                 * "and" in results from other servers. 
+                                /*
+                                 * "and" in results from other servers.
                                  * Remember that VFlagBS.SeqBody == VFlags.
                                  */
                                 for (int j = 0; j < numPiggyFids; j++)
@@ -814,11 +814,11 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                          GetComp(), numPiggyFids, numVFlags));
 
                     nchecked += numPiggyFids;
-                    /* 
-                     * now set status of piggybacked objects 
+                    /*
+                     * now set status of piggybacked objects
                      */
                     for (i = 0; i < numVFlags; i++) {
-                        /* 
+                        /*
                          * lookup this object. It may have been flushed and
                          * reincarnated as a runt in the while we were out,
                          * so we check status again.
@@ -842,8 +842,8 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                                     pobj->SetRcRights(RC_STATUS);
                                 else
                                     pobj->SetRcRights(RC_STATUS | RC_DATA);
-                                /* 
-                                 * if the object matched, the access rights 
+                                /*
+                                 * if the object matched, the access rights
                                  * cached for this object are still good.
                                  */
                                 if (pobj->IsDir()) {
@@ -867,7 +867,7 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                                     pobj->Demote();
 
                                 nfailed++;
-                                /* 
+                                /*
                                  * If we have data, it is stale and must be
                                  * discarded, unless someone is writing or
                                  * executing it, or it is a fake directory.
@@ -981,9 +981,9 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
                 if (code != 0)
                     goto RepExit;
 
-                /* 
-                 * Compute the dominant host set.  
-                 * The index of a dominant host is returned as a side-effect. 
+                /*
+                 * Compute the dominant host set.
+                 * The index of a dominant host is returned as a side-effect.
                  */
 
                 dh_ix = -1;

--- a/coda-src/venus/fso_cfscalls0.cc
+++ b/coda-src/venus/fso_cfscalls0.cc
@@ -604,7 +604,7 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
 {
     repvol *vp           = (repvol *)vol;
     connent *c           = NULL;
-    mgrpent *m           = 0;
+    mgrpent *m           = NULL;
     int code             = 0;
     int ret_code         = 0;
     int getacl           = (acl != 0);
@@ -660,11 +660,11 @@ int fsobj::GetAttr(uid_t uid, RPC2_BoundedBS *acl)
     PiggyBS.SeqBody = (RPC2_ByteSeq)PiggyData;
 
     if (vol->IsReadWrite()) {
-        cbtemp = cbbreaks;
-
         code = vp->GetConn(&c, uid, &m, &rpc_common.ph_ix, &ph_addr);
         if (code != 0)
             goto RepExit;
+
+        cbtemp = cbbreaks;
 
         rpc_common.ph = ntohl(ph_addr.s_addr);
 
@@ -1484,10 +1484,18 @@ int fsobj::SetAttr(struct coda_vattr *vap, uid_t uid)
 
 int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
 {
-    LOG(10, ("fsobj::SetACL: (%s), uid = %d\n", GetComp(), uid));
-
+    struct RPC2_common_params rpc_common;
+    struct in_addr ph_addr;
     ViceVersionVector UpdateSet;
-    long cbtemp = 0;
+    ViceStoreId sid;
+    long cbtemp     = 0;
+    int ret_code    = 0;
+    connent *c      = NULL;
+    mgrpent *m      = NULL;
+    int asy_resolve = 0;
+    repvol *vp      = (repvol *)vol;
+
+    LOG(10, ("fsobj::SetACL: (%s), uid = %d\n", GetComp(), uid));
 
     if (!REACHABLE(this))
         return ETIMEDOUT;
@@ -1536,51 +1544,65 @@ int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
     OldVS.SeqLen  = 0;
     OldVS.SeqBody = 0;
 
-    if (vol->IsReplicated()) {
-        ViceStoreId sid;
-        mgrpent *m      = 0;
-        int asy_resolve = 0;
-        repvol *vp      = (repvol *)vol;
-
-        /* Acquire an Mgroup. */
-        code = vp->GetMgrp(&m, uid, (PIGGYCOP2 ? &PiggyBS : 0));
+    if (vol->IsReadWrite()) {
+        code = vp->GetConn(&c, uid, &m, &rpc_common.ph_ix, &ph_addr);
         if (code != 0)
             goto RepExit;
 
-        /* The COP1 call. */
         cbtemp = cbbreaks;
+
+        rpc_common.ph = ntohl(ph_addr.s_addr);
+
+        if (vol->IsReplicated()) {
+            rpc_common.nservers = VSG_MEMBERS;
+            rpc_common.hosts    = m->rocc.hosts;
+            rpc_common.retcodes = m->rocc.retcodes;
+            rpc_common.handles  = m->rocc.handles;
+            rpc_common.MIp      = m->rocc.MIp;
+
+        } else { // Non-replicated
+
+            rpc_common.nservers = 1;
+            rpc_common.hosts    = &ph_addr;
+            rpc_common.retcodes = &ret_code;
+            rpc_common.handles  = &c->connid;
+            rpc_common.MIp      = 0;
+        }
 
         Recov_BeginTrans();
         Recov_GenerateStoreId(&sid);
         Recov_EndTrans(MAXFP);
         {
-            /* Make multiple copies of the IN/OUT and OUT parameters. */
-            int ph_ix;
-            unsigned long ph;
-            ph = ntohl(m->GetPrimaryHost(&ph_ix)->s_addr);
-            vp->PackVS(VSG_MEMBERS, &OldVS);
+            vp->PackVS(rpc_common.nservers, &OldVS);
 
             ARG_MARSHALL(IN_OUT_MODE, ViceStatus, statusvar, status,
-                         VSG_MEMBERS);
-            ARG_MARSHALL(OUT_MODE, RPC2_Integer, VSvar, VS, VSG_MEMBERS);
+                         rpc_common.nservers);
+            ARG_MARSHALL(OUT_MODE, RPC2_Integer, VSvar, VS,
+                         rpc_common.nservers);
             ARG_MARSHALL(OUT_MODE, CallBackStatus, VCBStatusvar, VCBStatus,
-                         VSG_MEMBERS)
+                         rpc_common.nservers)
 
             /* Make the RPC call. */
             CFSOP_PRELUDE("store::setacl %s\n", comp, fid);
             MULTI_START_MESSAGE(ViceSetACL_OP);
-            code = (int)MRPC_MakeMulti(ViceSetACL_OP, ViceSetACL_PTR,
-                                       VSG_MEMBERS, m->rocc.handles,
-                                       m->rocc.retcodes, m->rocc.MIp, 0, 0,
-                                       MakeViceFid(&fid), acl, statusvar_ptrs,
-                                       ph, &sid, &OldVS, VSvar_ptrs,
-                                       VCBStatusvar_ptrs, &PiggyBS);
+            code = (int)MRPC_MakeMulti(
+                ViceSetACL_OP, ViceSetACL_PTR, rpc_common.nservers,
+                rpc_common.handles, rpc_common.retcodes, rpc_common.MIp, 0, 0,
+                MakeViceFid(&fid), acl, statusvar_ptrs, rpc_common.ph, &sid,
+                &OldVS, VSvar_ptrs, VCBStatusvar_ptrs, &PiggyBS);
             MULTI_END_MESSAGE(ViceSetACL_OP);
             CFSOP_POSTLUDE("store::setacl done\n");
 
             /* Collate responses from individual servers and decide what to
-	     * do next. */
-            code = vp->Collate_COP1(m, code, &UpdateSet);
+             * do next. */
+            if (vol->IsReplicated()) {
+                code = vp->Collate_COP1(m, code, &UpdateSet);
+            } else {
+                code = vol->Collate(c, ret_code);
+                InitVV(&UpdateSet);
+                if (ret_code == 0)
+                    (&(UpdateSet.Versions.Site0))[0] = 1;
+            }
             MULTI_RECORD_STATS(ViceSetACL_OP);
 
             if (code == EASYRESOLVE) {
@@ -1590,30 +1612,38 @@ int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
             if (code != 0)
                 goto RepExit;
 
-            /* Collate volume callback information */
-            if (cbtemp == cbbreaks)
-                vp->CollateVCB(m, VSvar_bufs, VCBStatusvar_bufs);
+            if (vol->IsReplicated()) {
+                /* Collate volume callback information */
+                if (cbtemp == cbbreaks)
+                    vp->CollateVCB(m, VSvar_bufs, VCBStatusvar_bufs);
 
-            /* Finalize COP2 Piggybacking. */
-            if (PIGGYCOP2)
-                vp->ClearCOP2(&PiggyBS);
+                /* Finalize COP2 Piggybacking. */
+                if (PIGGYCOP2)
+                    vp->ClearCOP2(&PiggyBS);
 
-            /* Manually compute the OUT parameters from the mgrpent::SetAttr()
-	     * call! -JJK */
-            int dh_ix;
-            dh_ix = -1;
-            (void)m->DHCheck(0, ph_ix, &dh_ix);
-            ARG_UNMARSHALL(statusvar, status, dh_ix);
+                /* Manually compute the OUT parameters from the mgrpent::SetAttr()
+                 * call! -JJK */
+                int dh_ix;
+                dh_ix = -1;
+                (void)m->DHCheck(0, rpc_common.ph_ix, &dh_ix);
+                ARG_UNMARSHALL(statusvar, status, dh_ix);
+            } else { // IsNonReplicated
+                if (cbtemp == cbbreaks)
+                    ((reintvol *)this)
+                        ->UpdateVCBInfo(VSvar_bufs[0], VCBStatusvar_bufs[0]);
+            }
         }
 
         Recov_BeginTrans();
         UpdateStatus(&status, &UpdateSet, uid);
         Recov_EndTrans(CMFP);
-        if (ASYNCCOP2)
-            ReturnEarly();
+        if (vol->IsReplicated()) {
+            if (ASYNCCOP2)
+                ReturnEarly();
 
-        /* Send the COP2 message or add an entry for piggybacking. */
-        vp->COP2(m, &sid, &UpdateSet);
+            /* Send the COP2 message or add an entry for piggybacking. */
+            vp->COP2(m, &sid, &UpdateSet);
+        }
 
     RepExit:
         if (m)
@@ -1633,7 +1663,7 @@ int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
         default:
             break;
         }
-    } else {
+    } else { // !IsReadWrite
         /* Acquire a Connection. */
         connent *c;
         ViceStoreId Dummy; /* ViceStore needs an address for indirection */
@@ -1641,8 +1671,6 @@ int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
         code       = vp->GetConn(&c, uid);
         if (code != 0)
             goto NonRepExit;
-
-        vp->PackVS(1, &OldVS);
 
         /* The COP1 call. */
         cbtemp = cbbreaks;
@@ -1662,18 +1690,9 @@ int fsobj::SetACL(RPC2_CountedBS *acl, uid_t uid)
         if (code != 0)
             goto NonRepExit;
 
-        /* Update volume callback information */
-        if (cbtemp == cbbreaks)
-            vp->UpdateVCBInfo(VS, VCBStatus);
-
-        /* Non-replicated volumes still use the first slot */
-        InitVV(&UpdateSet);
-        if (vol->IsNonReplicated())
-            (&(UpdateSet.Versions.Site0))[0] = 1;
-
         /* Do setattr locally. */
         Recov_BeginTrans();
-        UpdateStatus(&status, &UpdateSet, uid);
+        UpdateStatus(&status, NULL, uid);
         Recov_EndTrans(CMFP);
 
     NonRepExit:

--- a/coda-src/venus/fso_cfscalls1.cc
+++ b/coda-src/venus/fso_cfscalls1.cc
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2018 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -750,7 +750,7 @@ int fsobj::SetVV(ViceVersionVector *newvv, uid_t uid)
         default:
             break;
         }
-    } else {
+    } else { // !IsReplicated (including non-replicated)
         /* Acquire a Connection. */
         connent *c;
         volrep *vp = (volrep *)vol;

--- a/coda-src/venus/hdb.cc
+++ b/coda-src/venus/hdb.cc
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2018 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -429,7 +429,7 @@ void hdb::ValidateCacheStatus(vproc *vp, int *interrupt_failures,
             continue;
 
         /* skip non-cacheable objects */
-        if (!f->vol->IsReplicated())
+        if (!f->vol->IsReadWrite())
             continue;
 
         /* Set up uarea. */

--- a/coda-src/venus/local_cml.cc
+++ b/coda-src/venus/local_cml.cc
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2016 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -610,7 +610,7 @@ int cmlent::DoRepair(char *msg, int rcode)
             vproc *vp = VprocSelf();
 
             VDB->Get(&vol, MakeVolid(fid));
-            CODA_ASSERT(vol && vol->IsReplicated());
+            CODA_ASSERT(vol && vol->IsReadWrite());
 
             repvol *rv = (repvol *)vol;
 

--- a/coda-src/venus/mgrp.h
+++ b/coda-src/venus/mgrp.h
@@ -39,6 +39,7 @@ class RepOpCommCtxt {
     friend class mgrpent;
     friend class fsobj;
     friend class repvol;
+    friend class reintvol;
     friend class volent;
     friend class vsgent;
     friend class ClientModifyLog;
@@ -79,6 +80,7 @@ class mgrpent : private RefCountedObject {
     friend class mgrp_iterator;
     friend class fsobj;
     friend class repvol;
+    friend class reintvol;
     friend class volent;
     friend class vsgent;
     friend class ClientModifyLog;

--- a/coda-src/venus/venus.private.h
+++ b/coda-src/venus/venus.private.h
@@ -79,7 +79,7 @@ extern "C" {
 #define	EINCOMPATIBLE	198
 #define	EINCONS		199
 */
-/* added for implementing ASRs.  Used to tell the vfs layer that 
+/* added for implementing ASRs.  Used to tell the vfs layer that
    an ASR was started and it should block */
 #define EASRSTARTED 200
 
@@ -115,7 +115,7 @@ extern uid_t V_UID; /* UID that the venus process runs under. */
 #else
 const uid_t V_UID = (uid_t)0; /* UID that the venus process runs under. */
 #endif
-/* Group id fields are 32 bits in BSD44 (not 16 bits); the use of a small 
+/* Group id fields are 32 bits in BSD44 (not 16 bits); the use of a small
    negative number (-2) means its unsigned long representation is huge
    (4294967294).  This causes the "ar" program to screw up because it
    blindly does a sprintf() of the gid into the ".a" file. (Satya, 1/11/97) */

--- a/coda-src/venus/venus.private.h
+++ b/coda-src/venus/venus.private.h
@@ -385,7 +385,7 @@ extern pid_t ASRpid;
 extern VenusFid ASRfid;
 extern uid_t ASRuid;
 
-struct RPC2_common_params {
+struct MRPC_common_params {
     RPC2_Integer nservers;
     RPC2_Handle *handles;
     struct in_addr *hosts;

--- a/coda-src/venus/venus.private.h
+++ b/coda-src/venus/venus.private.h
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2018 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -384,5 +384,15 @@ extern void MakeUserSpoolDir(char *, uid_t);
 extern pid_t ASRpid;
 extern VenusFid ASRfid;
 extern uid_t ASRuid;
+
+struct RPC2_common_params {
+    RPC2_Integer nservers;
+    RPC2_Handle *handles;
+    struct in_addr *hosts;
+    RPC2_Integer *retcodes;
+    int ph_ix;
+    unsigned long ph;
+    RPC2_Multicast *MIp;
+};
 
 #endif /* _VENUS_PRIVATE_H_ */

--- a/coda-src/venus/venuscb.cc
+++ b/coda-src/venus/venuscb.cc
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2016 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -297,8 +297,8 @@ long VENUS_CallBackFetch(RPC2_Handle RPCid, ViceFid *Fid, SE_Descriptor *BD)
 
         LOG(100, ("CallBackFetch: transferred %d bytes\n",
                   sid.Value.SmartFTPD.BytesTransferred));
-        if (f->vol->IsReplicated())
-            ((repvol *)f->vol)->BytesBackFetched +=
+        if (f->vol->IsReadWrite())
+            ((reintvol *)f->vol)->BytesBackFetched +=
                 sid.Value.SmartFTPD.BytesTransferred;
     }
 

--- a/coda-src/venus/venusvol.cc
+++ b/coda-src/venus/venusvol.cc
@@ -1094,8 +1094,7 @@ int volent::Enter(int mode, uid_t uid)
     vproc *vp = VprocSelf();
 
     reintvol *rv = (reintvol *)this;
-    if (VCBEnabled && IsReadWrite() && IsReachable() &&
-        rv->WantCallBack()) {
+    if (VCBEnabled && IsReadWrite() && IsReachable() && rv->WantCallBack()) {
         if ((!rv->HaveStamp() && vp->type == VPT_HDBDaemon) ||
             (rv->HaveStamp() &&
              (vp->type != VPT_VolDaemon || !just_transitioned))) {

--- a/coda-src/venus/venusvol.cc
+++ b/coda-src/venus/venusvol.cc
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2018 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under

--- a/coda-src/venus/venusvol.cc
+++ b/coda-src/venus/venusvol.cc
@@ -1296,8 +1296,8 @@ void volent::Exit(int mode, uid_t uid)
         LOG(1, ("volent::Exit: demoting %s\n", name));
         flags.demotion_pending = 0;
 
-        if (IsReplicated())
-            ((repvol *)this)->ClearCallBack();
+        if (IsReadWrite())
+            ((reintvol *)this)->ClearCallBack();
 
         struct dllist_head *p;
         list_for_each(p, fso_list)
@@ -1889,6 +1889,8 @@ int reintvol::GetConn(connent **c, uid_t uid, mgrpent **m, int *ph_ix,
     struct in_addr *phost_tmp = NULL;
     struct in_addr phost_tmp2;
     int ph_ix_tmp = 0;
+
+    CODA_ASSERT(IsReadWrite());
 
     *c = NULL;
     if (m)

--- a/coda-src/venus/venusvol.cc
+++ b/coda-src/venus/venusvol.cc
@@ -2884,6 +2884,11 @@ repvol_iterator::repvol_iterator(Volid *key)
 {
 }
 
+nonrepvol_iterator::nonrepvol_iterator(Volid *key)
+    : volent_iterator(VDB->volrep_hash, key)
+{
+}
+
 volrep_iterator::volrep_iterator(Volid *key)
     : volent_iterator(VDB->volrep_hash, key)
 {
@@ -2937,6 +2942,18 @@ volrep *volrep_iterator::operator()()
         return (0);
     assert(!v->IsReplicated());
     return (volrep *)v;
+}
+
+reintvol *nonrepvol_iterator::operator()()
+{
+    volent *v;
+
+    while ((v = volent_iterator::operator()())) {
+        if (v->IsNonReplicated())
+            return (reintvol *)v;
+    }
+
+    return (0);
 }
 
 reintvol::reintvol(Realm *r, VolumeId volid, const char *volname)

--- a/coda-src/venus/venusvol.cc
+++ b/coda-src/venus/venusvol.cc
@@ -1059,7 +1059,7 @@ int volent::Enter(int mode, uid_t uid)
         LOG(1, ("volent::Enter: demoting %s\n", name));
         flags.demotion_pending = 0;
 
-        if (IsReplicated() || IsNonReplicated())
+        if (IsReadWrite())
             ((reintvol *)this)->ClearCallBack();
 
         struct dllist_head *p;
@@ -1094,7 +1094,7 @@ int volent::Enter(int mode, uid_t uid)
     vproc *vp = VprocSelf();
 
     reintvol *rv = (reintvol *)this;
-    if (VCBEnabled && (IsReplicated() || IsNonReplicated()) && IsReachable() &&
+    if (VCBEnabled && IsReadWrite() && IsReachable() &&
         rv->WantCallBack()) {
         if ((!rv->HaveStamp() && vp->type == VPT_HDBDaemon) ||
             (rv->HaveStamp() &&

--- a/coda-src/venus/venusvol.cc
+++ b/coda-src/venus/venusvol.cc
@@ -1059,8 +1059,8 @@ int volent::Enter(int mode, uid_t uid)
         LOG(1, ("volent::Enter: demoting %s\n", name));
         flags.demotion_pending = 0;
 
-        if (IsReplicated())
-            ((repvol *)this)->ClearCallBack();
+        if (IsReplicated() || IsNonReplicated())
+            ((reintvol *)this)->ClearCallBack();
 
         struct dllist_head *p;
         list_for_each(p, fso_list)
@@ -1092,9 +1092,10 @@ int volent::Enter(int mode, uid_t uid)
      * only if a request arrives in the next few (5) seconds!
      */
     vproc *vp = VprocSelf();
-    if (VCBEnabled && IsReplicated() && IsReachable() &&
-        ((repvol *)this)->WantCallBack()) {
-        repvol *rv = (repvol *)this;
+
+    reintvol *rv = (reintvol *)this;
+    if (VCBEnabled && (IsReplicated() || IsNonReplicated()) && IsReachable() &&
+        rv->WantCallBack()) {
         if ((!rv->HaveStamp() && vp->type == VPT_HDBDaemon) ||
             (rv->HaveStamp() &&
              (vp->type != VPT_VolDaemon || !just_transitioned))) {
@@ -1132,8 +1133,6 @@ int volent::Enter(int mode, uid_t uid)
              * mutator needs to aquire exclusive CML ownership
              */
             if (IsReadWrite()) {
-                reintvol *rv = (reintvol *)this;
-
                 /*
                  * Claim ownership if the volume is free.
                  * The CML lock is used to prevent checkpointers and

--- a/coda-src/venus/venusvol.cc
+++ b/coda-src/venus/venusvol.cc
@@ -1436,7 +1436,7 @@ void volent::TakeTransition()
         if (rv->IsSync())
             rv->Reintegrate();
         else if (rv->ReadyToReintegrate() && IsReplicated())
-            ::Reintegrate((repvol *)rv);
+            ::Reintegrate(rv);
         // Fall through
 
     case Unreachable:

--- a/coda-src/venus/venusvol.cc
+++ b/coda-src/venus/venusvol.cc
@@ -754,19 +754,33 @@ void vdb::UpEvent(struct in_addr *host)
 /* MUST be called from within transaction! */
 void vdb::AttachFidBindings()
 {
-    repvol_iterator next;
-    repvol *v;
-    while ((v = next()))
+    repvol_iterator r_next;
+    nonrepvol_iterator nr_next;
+    reintvol *v;
+
+    while ((v = (reintvol *)r_next())) {
         v->CML.AttachFidBindings();
+    }
+
+    while ((v = nr_next())) {
+        v->CML.AttachFidBindings();
+    }
 }
 
 int vdb::WriteDisconnect(unsigned int age, unsigned int time)
 {
-    repvol_iterator next;
-    repvol *v;
+    repvol_iterator r_next;
+    nonrepvol_iterator nr_next;
+    reintvol *v;
     int code = 0;
 
-    while ((v = next())) {
+    while ((v = (reintvol *)r_next())) {
+        code = v->WriteDisconnect(age, time);
+        if (code)
+            break;
+    }
+
+    while ((v = nr_next())) {
         code = v->WriteDisconnect(age, time);
         if (code)
             break;
@@ -776,24 +790,19 @@ int vdb::WriteDisconnect(unsigned int age, unsigned int time)
 
 int vdb::SyncCache()
 {
-    repvol_iterator next;
-    volrep_iterator nrnext;
-    repvol *v;
-    volrep *nrv;
+    repvol_iterator r_next;
+    nonrepvol_iterator nr_next;
+    reintvol *v;
     int code = 0;
 
-    while ((v = next())) {
+    while ((v = (reintvol *)r_next())) {
         code = v->SyncCache();
         if (code)
             break;
     }
 
-    while ((nrv = nrnext())) {
-        if (!nrv->IsNonReplicated())
-            continue;
-
-        code = nrv->SyncCache();
-
+    while ((v = nr_next())) {
+        code = v->SyncCache();
         if (code)
             break;
     }
@@ -804,9 +813,18 @@ int vdb::SyncCache()
 void vdb::GetCmlStats(cmlstats &total_current, cmlstats &total_cancelled)
 {
     /* N.B.  We assume that caller has passed in zeroed-out structures! */
-    repvol_iterator next;
-    repvol *v;
-    while ((v = next())) {
+    repvol_iterator r_next;
+    nonrepvol_iterator nr_next;
+    reintvol *v;
+
+    while ((v = (reintvol *)r_next())) {
+        cmlstats current, cancelled;
+        v->CML.IncGetStats(current, cancelled);
+        total_current += current;
+        total_cancelled += cancelled;
+    }
+
+    while ((v = nr_next())) {
         cmlstats current, cancelled;
         v->CML.IncGetStats(current, cancelled);
         total_current += current;
@@ -822,10 +840,12 @@ void vdb::print(int fd, int SummaryOnly)
     fdprint(fd, "volume callbacks broken = %d, total callbacks broken = %d\n",
             vcbbreaks, cbbreaks);
     if (!SummaryOnly) {
-        repvol_iterator rvnext;
-        volrep_iterator vrnext;
-        volent *v;
-        while ((v = rvnext()) || (v = vrnext()))
+        repvol_iterator r_next;
+        nonrepvol_iterator nr_next;
+        reintvol *v;
+        while ((v = (reintvol *)r_next()))
+            v->print(fd);
+        while ((v = nr_next()))
             v->print(fd);
     }
 
@@ -834,11 +854,13 @@ void vdb::print(int fd, int SummaryOnly)
 
 void vdb::ListCache(FILE *fp, int long_format, unsigned int valid)
 {
-    repvol_iterator rvnext;
-    volrep_iterator vrnext;
-    volent *v = 0;
+    repvol_iterator r_next;
+    nonrepvol_iterator nr_next;
+    reintvol *v;
 
-    while ((v = rvnext()) || (v = vrnext()))
+    while ((v = (reintvol *)r_next()))
+        v->ListCache(fp, long_format, valid);
+    while ((v = nr_next()))
         v->ListCache(fp, long_format, valid);
 }
 

--- a/coda-src/venus/venusvol.h
+++ b/coda-src/venus/venusvol.h
@@ -743,6 +743,7 @@ class reintvol : public volent {
     friend class volent;
     friend class cmlent;
     friend class vdb;
+    friend long VENUS_CallBackFetch(RPC2_Handle, ViceFid *, SE_Descriptor *);
 
 private:
 protected:

--- a/coda-src/venus/venusvol.h
+++ b/coda-src/venus/venusvol.h
@@ -920,6 +920,7 @@ public:
 class repvol : public reintvol {
     friend class cmlent;
     friend class fsobj;
+    friend class reintvol;
     friend class vdb;
     friend class volent; /* CML_Lock */
     friend long VENUS_CallBackFetch(RPC2_Handle, ViceFid *, SE_Descriptor *);

--- a/coda-src/venus/venusvol.h
+++ b/coda-src/venus/venusvol.h
@@ -488,6 +488,7 @@ class vdb {
     friend class cmlent;
     friend class volrep; /* for hashtab insert/remove */
     friend class repvol; /* for hashtab insert/remove */
+    friend class nonrepvol_iterator;
     friend class repvol_iterator;
     friend class volrep_iterator;
     friend class fsobj;
@@ -1011,6 +1012,12 @@ class repvol_iterator : public volent_iterator {
 public:
     repvol_iterator(Volid * = (Volid *)-1);
     repvol *operator()();
+};
+
+class nonrepvol_iterator : public volent_iterator {
+public:
+    nonrepvol_iterator(Volid * = (Volid *)-1);
+    reintvol *operator()();
 };
 
 class volrep_iterator : public volent_iterator {

--- a/coda-src/venus/venusvol.h
+++ b/coda-src/venus/venusvol.h
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2018 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -766,6 +766,11 @@ protected:
     /*T*/ long BytesBackFetched;
     /*?*/ cmlent *reintegrate_done; /* WriteBack Caching */
 
+    /* Callback stuff */
+    /*T*/ CallBackStatus VCBStatus; /* do we have a volume callback? */
+    /*T*/ int VCBHits; /* # references hitting this callback */
+    ViceVersionVector VVV; /* (maximal) volume version vector */
+
 public:
     reintvol(Realm *r, VolumeId volid, const char *volname);
 
@@ -849,6 +854,18 @@ public:
     void PreserveLocalMutation(char *msg);
     void DiscardAllLocalMutation(char *msg);
     void DiscardLocalMutation(char *msg);
+
+    /* Callbacks routines */
+    int HaveCallBack() { return (VCBStatus == CallBackSet); }
+    int CallBackBreak();
+    void ClearCallBack();
+    void SetCallBack();
+    int WantCallBack();
+    int ValidateFSOs();
+    int GetVolAttr(uid_t);
+    void UpdateVCBInfo(RPC2_Integer VS, CallBackStatus CBStatus);
+    void PackVS(int, RPC2_CountedBS *);
+    int HaveStamp() { return (VV_Cmp(&VVV, &NullVV) != VV_EQ); }
 };
 
 class srvent;
@@ -919,11 +936,6 @@ class repvol : public reintvol {
     /* COP2 stuff. */
     /*T*/ dlist *cop2_list;
 
-    /* Callback stuff */
-    /*T*/ CallBackStatus VCBStatus; /* do we have a volume callback? */
-    /*T*/ int VCBHits; /* # references hitting this callback */
-    ViceVersionVector VVV; /* (maximal) volume version vector */
-
     repvol(Realm *r, VolumeId vid, const char *name, volrep *reps[VSG_MEMBERS]);
     ~repvol();
     void ResetTransient();
@@ -983,17 +995,7 @@ public:
     void ClearCOP2(RPC2_CountedBS *);
     void ClearCOP2(void);
 
-    /* Callback routines */
-    int GetVolAttr(uid_t);
     void CollateVCB(mgrpent *, RPC2_Integer *, CallBackStatus *);
-    void PackVS(int, RPC2_CountedBS *);
-    int HaveStamp() { return (VV_Cmp(&VVV, &NullVV) != VV_EQ); }
-    int HaveCallBack() { return (VCBStatus == CallBackSet); }
-    int CallBackBreak();
-    void ClearCallBack();
-    void SetCallBack();
-    int WantCallBack();
-    int ValidateFSOs();
 
     void print_repvol(int);
 };

--- a/coda-src/venus/venusvol.h
+++ b/coda-src/venus/venusvol.h
@@ -926,7 +926,7 @@ class repvol : public reintvol {
     friend class volent; /* CML_Lock */
     friend long VENUS_CallBackFetch(RPC2_Handle, ViceFid *, SE_Descriptor *);
     friend void Resolve(volent *);
-    friend void Reintegrate(repvol *);
+    friend void Reintegrate(reintvol *);
     friend void VolInit(void);
 
     volrep *volreps[VSG_MEMBERS]; /* underlying volume replicas */
@@ -1109,7 +1109,7 @@ const unsigned int COP2SIZE = 1024;
 extern void VOLD_Init(void);
 
 /* vol_reintegrate.c */
-extern void Reintegrate(repvol *);
+void Reintegrate(reintvol *);
 
 /* vol_resolve.c */
 extern void Resolve(volent *);

--- a/coda-src/venus/vol_cml.cc
+++ b/coda-src/venus/vol_cml.cc
@@ -2346,11 +2346,9 @@ int ClientModifyLog::COP1_NR(char *buf, int bufsize,
     }
 
     /* Update volume callback information */
-    if (cbtemp == cbbreaks && VCBStatus == CallBackSet) {
-        vol->SetCallBack();
-        vol->VVV.Versions.Site0 = VS;
-    } else
-        vol->CallBackBreak();
+    if (cbtemp == cbbreaks) {
+        vol->UpdateVCBInfo(VS, VCBStatus);
+    }
 
     bufsize += sed.Value.SmartFTPD.BytesTransferred;
     LOG(10, ("ViceReintegrate: transferred %d bytes\n",
@@ -2358,6 +2356,10 @@ int ClientModifyLog::COP1_NR(char *buf, int bufsize,
 
     /* Purge off stale directory fids, if any. fsobj::Kill is idempotent. */
     LOG(0, ("ClientModifyLog::COP1_NR: %d stale dirs\n", NumStaleDirs));
+
+    /* server may have found more stale dirs */
+	if (NumStaleDirs == MaxStaleDirs)
+	    vol->ClearCallBack();
 
     for (unsigned int d = 0; d < NumStaleDirs; d++) {
         VenusFid StaleDir;

--- a/coda-src/venus/vol_cml.cc
+++ b/coda-src/venus/vol_cml.cc
@@ -157,12 +157,12 @@ void ClientModifyLog::IncGetStats(cmlstats &current, cmlstats &cancelled,
     cancelled = cancellations;
 }
 
-/* 
+/*
  * called after a reintegration failure to remove cmlents that would
  * have been cancelled had reintegration not been in progress.
  * Unfreezes records; cancel requires this.  Since this routine is
  * called only if the failure involved receiving a response from the
- * server (i.e., outcome is known), it is safe to unfreeze the records.  
+ * server (i.e., outcome is known), it is safe to unfreeze the records.
  */
 void ClientModifyLog::CancelPending()
 {
@@ -189,7 +189,7 @@ void ClientModifyLog::CancelPending()
 
 /*
  * called after reintegration success to clear cancellations
- * pending failure.  this is necessary because records in 
+ * pending failure.  this is necessary because records in
  * the log tail (not involved in reintegration) may be marked.
  */
 void ClientModifyLog::ClearPending()
@@ -206,8 +206,8 @@ void ClientModifyLog::ClearPending()
         }
 }
 
-/* 
- * Scans the log, cancelling stores for open-for-write files. 
+/*
+ * Scans the log, cancelling stores for open-for-write files.
  * Note it might delete a record out from under itself.
  */
 void ClientModifyLog::CancelStores()
@@ -281,7 +281,7 @@ void cmlent::Thaw()
     flags.frozen = 0;
 }
 
-/* 
+/*
  * Scan the log for reintegrateable records, subject to the
  * reintegration time limit, and mark them with the given
  * tid. Note the time limit does not apply to ASRs.
@@ -469,9 +469,9 @@ void ClientModifyLog::MarkCommittedMLE(RPC2_Unsigned Uniquifier)
   failedmle - the entry point of handling reintegration failure or
   local-global conflicts
 */
-/* 
+/*
  * Handle a non-retryable failure.  The offending record
- * was marked and may or may not still be there. 
+ * was marked and may or may not still be there.
  * Note that an abort may delete a record out from under us.
  */
 void ClientModifyLog::HandleFailedMLE(void)
@@ -1175,15 +1175,15 @@ int reintvol::LogRemove(time_t Mtime, uid_t uid, VenusFid *PFid, char *Name,
 
     if (LogOpts && !prepend) {
         if (LinkCount == 1) {
-            /* 
-	     * if the object was created here, we may be able to do an 
-	     * identity cancellation.  However, if the create is frozen,
-	     * we cannot cancel records involved in an identity cancellation,
-	     * because the create may have already become visible at the servers.
-	     * Mark such records in case reintegration fails.  Records for which 
-	     * this remove is an overwrite may be cancelled either way.  If they 
-	     * are frozen cmlent::cancel does the right thing.
-	     */
+            /*
+             * if the object was created here, we may be able to do an
+             * identity cancellation.  However, if the create is frozen,
+             * we cannot cancel records involved in an identity cancellation,
+             * because the create may have already become visible at the servers.
+             * Mark such records in case reintegration fails.  Records for which
+             * this remove is an overwrite may be cancelled either way. If they
+             * are frozen cmlent::cancel does the right thing.
+             */
             int CreateReintegrating = 0;
             {
                 cml_iterator next(CML, CommitOrder, CFid);
@@ -1195,11 +1195,11 @@ int reintvol::LogRemove(time_t Mtime, uid_t uid, VenusFid *PFid, char *Name,
                         CreateReintegrating = 1;
                 }
                 /*
-		if (ObjectCreated) {
-		    int code = LogUtimes(Mtime, uid, PFid, Mtime);
-		    if (code != 0) return(code);
-		}
-*/
+                if (ObjectCreated) {
+                    int code = LogUtimes(Mtime, uid, PFid, Mtime);
+                    if (code != 0) return(code);
+                }
+                */
             }
 
             int cancellation;
@@ -1585,7 +1585,7 @@ int cmlent::cancel()
         }
     }
 
-    /* 
+    /*
      * If this record is being reintegrated, just mark it for
      * cancellation and we'll get to it later.
      */
@@ -1816,7 +1816,7 @@ int cmlent::cancel()
     return 1;
 }
 
-/* 
+/*
  * If this record is a store corresponding to an open-for-write file,
  * cancel it and restore the object's attributes to their old values.
  */
@@ -2078,12 +2078,12 @@ int ClientModifyLog::COP1(char *buf, int bufsize, ViceVersionVector *UpdateSet,
         code = vol->Collate(c, code, 0);
         UNI_RECORD_STATS(ViceReintegrate_OP);
 
-        /* 
-	 * if the return code is EALREADY, the log records up to and
-	 * including the one with the storeid that matches the 
-	 * uniquifier in Index have been committed at the server.  
-	 * Mark the last of those records.
-	 */
+        /*
+         * if the return code is EALREADY, the log records up to and
+         * including the one with the storeid that matches the
+         * uniquifier in Index have been committed at the server.
+         * Mark the last of those records.
+         */
         if (code == EALREADY)
             MarkCommittedMLE((RPC2_Unsigned)Index);
 
@@ -2166,8 +2166,8 @@ int ClientModifyLog::COP1(char *buf, int bufsize, ViceVersionVector *UpdateSet,
         free(OldVS.SeqBody);
 
         /* Collate the failure index.  Grab the smallest one. Take special
-	 * care to treat the index different when an error is returned.
-	 * This double usage of the index is really asking for trouble! */
+         * care to treat the index different when an error is returned.
+         * This double usage of the index is really asking for trouble! */
         for (i = 0; i < VSG_MEMBERS; i++) {
             if (m->rocc.hosts[i].s_addr != 0) {
                 if ((code != EALREADY || m->rocc.retcodes[i] == EALREADY) &&
@@ -2176,12 +2176,12 @@ int ClientModifyLog::COP1(char *buf, int bufsize, ViceVersionVector *UpdateSet,
             }
         }
 
-        /* 
-	 * if the return code is EALREADY, the log records up to and
-	 * including the one with the storeid that matches the 
-	 * uniquifier in Index have been committed at the server.  
-	 * Mark the last of those records.
-	 */
+        /*
+         * if the return code is EALREADY, the log records up to and
+         * including the one with the storeid that matches the
+         * uniquifier in Index have been committed at the server.
+         * Mark the last of those records.
+         */
         if (code == EALREADY)
             MarkCommittedMLE((RPC2_Unsigned)Index);
 
@@ -2213,13 +2213,13 @@ int ClientModifyLog::COP1(char *buf, int bufsize, ViceVersionVector *UpdateSet,
         LOG(10, ("ViceReintegrate: transferred %d bytes\n",
                  sedvar_bufs[dh_ix].Value.SmartFTPD.BytesTransferred));
 
-        /* 
-	 * Deal with stale directory fids, if any.  If the client
-	 * has a volume callback, stale directories must be purged.
-	 * If not, purging the directories saves an inevitable 
-	 * validation.  Finally, if the number of stale directories
-	 * found is at maximum, clear the volume callback to be safe.
-	 */
+        /*
+         * Deal with stale directory fids, if any.  If the client
+         * has a volume callback, stale directories must be purged.
+         * If not, purging the directories saves an inevitable
+         * validation.  Finally, if the number of stale directories
+         * found is at maximum, clear the volume callback to be safe.
+         */
         for (unsigned int rep = 0; rep < VSG_MEMBERS; rep++)
             /* did this server participate? */
             if (m->rocc.hosts[rep].s_addr != 0) {
@@ -2328,10 +2328,10 @@ int ClientModifyLog::COP1_NR(char *buf, int bufsize,
 
     free(OldVS.SeqBody);
 
-    /* 
+    /*
      * if the return code is EALREADY, the log records up to and
-     * including the one with the storeid that matches the 
-     * uniquifier in Index have been committed at the server.  
+     * including the one with the storeid that matches the
+     * uniquifier in Index have been committed at the server.
      * Mark the last of those records.
      */
     if (code == EALREADY)
@@ -2428,7 +2428,7 @@ void ClientModifyLog::IncCommit(ViceVersionVector *UpdateSet, int Tid)
     LOG(0, ("ClientModifyLog::IncCommit: (%s)\n", vol->name));
 }
 
-/* Allocate a real fid for a locally created one, and translate all 
+/* Allocate a real fid for a locally created one, and translate all
    references. */
 /* Must NOT be called from within transaction! */
 int cmlent::realloc()
@@ -2746,11 +2746,11 @@ void cmlent::commit(ViceVersionVector *UpdateSet)
     repvol *rv    = (repvol *)vol;
     vol->RecordsCommitted++;
 
-    /* 
-     * Record StoreId/UpdateSet for objects involved in this operation ONLY 
-     * when this is the  FINAL mutation of the object.  Record a COP2 entry 
-     * only if this operation was final for ANY object! 
-     * Because of the addition of incremental reintegration, the final 
+    /*
+     * Record StoreId/UpdateSet for objects involved in this operation ONLY
+     * when this is the  FINAL mutation of the object. Record a COP2 entry
+     * only if this operation was final for ANY object!
+     * Because of the addition of incremental reintegration, the final
      * mutation should be checked only within the bound of a single unit
      * (identified by cmlent::tid) -luqi
      */
@@ -2779,10 +2779,10 @@ void cmlent::commit(ViceVersionVector *UpdateSet)
         cmlent *FinalCmlent = f->FinalCmlent(tid);
         if (FinalCmlent == this) {
             LOG(10, ("cmlent::commit: FinalCmlent for %s\n", FID_(&f->fid)));
-            /* 
-	     * if the final update removed the object, don't bother adding the
-	     * COP2, but do update the version vector as in connected mode.
-	     */
+            /*
+             * if the final update removed the object, don't bother adding the
+             * COP2, but do update the version vector as in connected mode.
+             */
             if (!(opcode == CML_Remove_OP &&
                   FID_EQ(&u.u_remove.CFid, &f->fid)) &&
                 !(opcode == CML_RemoveDir_OP &&
@@ -3307,13 +3307,13 @@ int reintvol::PurgeMLEs(uid_t uid)
             d = next();
             Recov_BeginTrans();
             if (m->IsToBeRepaired())
-                /* 
-		       * this record must be associated with
-		       * some local objects whose subtree root	
-		       * is not in this volume. since we kill the
-		       * local objects later, we use cmlent destructor
-		       * instead of the cmlent::abort().
-		       */
+                /*
+                 * this record must be associated with
+                 * some local objects whose subtree root
+                 * is not in this volume. since we kill the
+                 * local objects later, we use cmlent destructor
+                 * instead of the cmlent::abort().
+                 */
                 delete m;
             else
                 m->abort();
@@ -3889,9 +3889,9 @@ int cmlent::Aged()
     return 0;
 }
 
-/* 
+/*
  * simpleminded routine to estimate the amount of time to reintegrate
- * this record (in milleseconds), given an estimate of bandwidth in 
+ * this record (in milleseconds), given an estimate of bandwidth in
  * bytes/second.
  */
 unsigned long cmlent::ReintTime(unsigned long bw)

--- a/coda-src/venus/vol_cml.cc
+++ b/coda-src/venus/vol_cml.cc
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
 			    Coda File System
-				Release 6
+				Release 7
 
-	    Copyright (c) 1987-2018 Carnegie Mellon University
+	    Copyright (c) 1987-2019 Carnegie Mellon University
 		    Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -2309,6 +2309,7 @@ int ClientModifyLog::COP1_NR(char *buf, int bufsize,
     /* don't bother with VCBs, will lose them on resolve anyway */
     RPC2_CountedBS OldVS;
     OldVS.SeqLen = 0;
+    vol->ClearCallBack();
 
     /* Make the RPC call. */
     MarinerLog("store::Reintegrate %s, (%d, %d)\n", vol->name, count(),
@@ -2345,13 +2346,11 @@ int ClientModifyLog::COP1_NR(char *buf, int bufsize,
     }
 
     /* Update volume callback information */
-#if TOBEDONE
     if (cbtemp == cbbreaks && VCBStatus == CallBackSet) {
         vol->SetCallBack();
-        vol->VVV.Site0 = VS;
+        vol->VVV.Versions.Site0 = VS;
     } else
         vol->CallBackBreak();
-#endif
 
     bufsize += sed.Value.SmartFTPD.BytesTransferred;
     LOG(10, ("ViceReintegrate: transferred %d bytes\n",

--- a/coda-src/venus/vol_cml.cc
+++ b/coda-src/venus/vol_cml.cc
@@ -1175,7 +1175,7 @@ int reintvol::LogRemove(time_t Mtime, uid_t uid, VenusFid *PFid, char *Name,
 
     if (LogOpts && !prepend) {
         if (LinkCount == 1) {
-            /*
+            /* 
 	     * if the object was created here, we may be able to do an 
 	     * identity cancellation.  However, if the create is frozen,
 	     * we cannot cancel records involved in an identity cancellation,
@@ -2078,7 +2078,7 @@ int ClientModifyLog::COP1(char *buf, int bufsize, ViceVersionVector *UpdateSet,
         code = vol->Collate(c, code, 0);
         UNI_RECORD_STATS(ViceReintegrate_OP);
 
-        /*
+        /* 
 	 * if the return code is EALREADY, the log records up to and
 	 * including the one with the storeid that matches the 
 	 * uniquifier in Index have been committed at the server.  
@@ -2176,7 +2176,7 @@ int ClientModifyLog::COP1(char *buf, int bufsize, ViceVersionVector *UpdateSet,
             }
         }
 
-        /*
+        /* 
 	 * if the return code is EALREADY, the log records up to and
 	 * including the one with the storeid that matches the 
 	 * uniquifier in Index have been committed at the server.  
@@ -2213,7 +2213,7 @@ int ClientModifyLog::COP1(char *buf, int bufsize, ViceVersionVector *UpdateSet,
         LOG(10, ("ViceReintegrate: transferred %d bytes\n",
                  sedvar_bufs[dh_ix].Value.SmartFTPD.BytesTransferred));
 
-        /*
+        /* 
 	 * Deal with stale directory fids, if any.  If the client
 	 * has a volume callback, stale directories must be purged.
 	 * If not, purging the directories saves an inevitable 
@@ -2309,7 +2309,7 @@ int ClientModifyLog::COP1_NR(char *buf, int bufsize,
     /* don't bother with VCBs, will lose them on resolve anyway */
     RPC2_CountedBS OldVS;
     OldVS.SeqLen = 0;
-    vol->ClearCallBack();
+    vol->PackVS(1, &OldVS);
 
     /* Make the RPC call. */
     MarinerLog("store::Reintegrate %s, (%d, %d)\n", vol->name, count(),
@@ -2326,7 +2326,9 @@ int ClientModifyLog::COP1_NR(char *buf, int bufsize,
     code = vol->Collate(c, code, 0);
     UNI_RECORD_STATS(ViceReintegrate_OP);
 
-    /*
+    free(OldVS.SeqBody);
+
+    /* 
      * if the return code is EALREADY, the log records up to and
      * including the one with the storeid that matches the 
      * uniquifier in Index have been committed at the server.  
@@ -2340,6 +2342,7 @@ int ClientModifyLog::COP1_NR(char *buf, int bufsize,
         code != EWOULDBLOCK && code != ETIMEDOUT)
         MarkFailedMLE((int)Index);
 
+    if (code == EASYRESOLVE) { code = 0; }
     if (code != 0) {
         PutConn(&c);
         goto ExitNonRep;
@@ -2358,8 +2361,8 @@ int ClientModifyLog::COP1_NR(char *buf, int bufsize,
     LOG(0, ("ClientModifyLog::COP1_NR: %d stale dirs\n", NumStaleDirs));
 
     /* server may have found more stale dirs */
-	if (NumStaleDirs == MaxStaleDirs)
-	    vol->ClearCallBack();
+    if (NumStaleDirs == MaxStaleDirs)
+        vol->ClearCallBack();
 
     for (unsigned int d = 0; d < NumStaleDirs; d++) {
         VenusFid StaleDir;
@@ -2741,7 +2744,7 @@ void cmlent::commit(ViceVersionVector *UpdateSet)
     repvol *rv    = (repvol *)vol;
     vol->RecordsCommitted++;
 
-    /*
+    /* 
      * Record StoreId/UpdateSet for objects involved in this operation ONLY 
      * when this is the  FINAL mutation of the object.  Record a COP2 entry 
      * only if this operation was final for ANY object! 
@@ -2774,7 +2777,7 @@ void cmlent::commit(ViceVersionVector *UpdateSet)
         cmlent *FinalCmlent = f->FinalCmlent(tid);
         if (FinalCmlent == this) {
             LOG(10, ("cmlent::commit: FinalCmlent for %s\n", FID_(&f->fid)));
-            /*
+            /* 
 	     * if the final update removed the object, don't bother adding the
 	     * COP2, but do update the version vector as in connected mode.
 	     */
@@ -3302,13 +3305,13 @@ int reintvol::PurgeMLEs(uid_t uid)
             d = next();
             Recov_BeginTrans();
             if (m->IsToBeRepaired())
-                /*
-                 * this record must be associated with
-                 * some local objects whose subtree root
-                 * is not in this volume. since we kill the
-                 * local objects later, we use cmlent destructor
-                 * instead of the cmlent::abort().
-                 */
+                /* 
+		       * this record must be associated with
+		       * some local objects whose subtree root	
+		       * is not in this volume. since we kill the
+		       * local objects later, we use cmlent destructor
+		       * instead of the cmlent::abort().
+		       */
                 delete m;
             else
                 m->abort();

--- a/coda-src/venus/vol_cml.cc
+++ b/coda-src/venus/vol_cml.cc
@@ -2342,7 +2342,9 @@ int ClientModifyLog::COP1_NR(char *buf, int bufsize,
         code != EWOULDBLOCK && code != ETIMEDOUT)
         MarkFailedMLE((int)Index);
 
-    if (code == EASYRESOLVE) { code = 0; }
+    if (code == EASYRESOLVE) {
+        code = 0;
+    }
     if (code != 0) {
         PutConn(&c);
         goto ExitNonRep;

--- a/coda-src/venus/vol_cml.cc
+++ b/coda-src/venus/vol_cml.cc
@@ -368,7 +368,7 @@ int ClientModifyLog::GetReintegrateable(int tid, unsigned long *reint_time,
  */
 cmlent *ClientModifyLog::GetFatHead(int tid)
 {
-    repvol *vol = strbase(repvol, this, CML);
+    reintvol *vol = strbase(reintvol, this, CML);
     cmlent *m;
     cml_iterator next(*this, CommitOrder);
     unsigned long bw; /* bandwidth in bytes/sec */
@@ -3097,7 +3097,7 @@ int cmlent::CloseReintegrationHandle(char *buf, int bufsize,
     /* don't bother with VCBs, will lose them on resolve anyway */
     RPC2_CountedBS OldVS;
     OldVS.SeqLen = 0;
-    if (vol->IsReplicated())
+    if (vol->IsReadWrite())
         rv->ClearCallBack();
 
     /* Make the RPC call. */
@@ -3715,7 +3715,7 @@ void cmlent::AttachFidBindings()
         fsobj *f = FSDB->Find(fidp);
         if (f == 0) {
             print(logFile);
-            (strbase(repvol, log, CML))->print(logFile);
+            (strbase(reintvol, log, CML))->print(logFile);
             CHOKE("cmlent::AttachFidBindings: can't find (%s)", FID_(fidp));
         }
 

--- a/coda-src/venus/vol_daemon.cc
+++ b/coda-src/venus/vol_daemon.cc
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2018 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -241,9 +241,20 @@ void TrickleReintegrate()
     LOG(100, ("TrickleReintegrate(): \n"));
 
     /* For each volume. */
-    repvol_iterator next;
-    repvol *v;
-    while ((v = next())) {
+    repvol_iterator r_next;
+    nonrepvol_iterator nr_next;
+    reintvol *v;
+    while ((v = (reintvol *)r_next())) {
+        LOG(1000, ("TrickleReintegrate: checking %s\n", v->GetName()));
+        if (v->Enter((VM_OBSERVING | VM_NDELAY), V_UID) == 0) {
+            /* force a connectivity check? */
+            /* try to propagate updates from this volume.  */
+            if (v->ReadyToReintegrate())
+                ::Reintegrate(v);
+            v->Exit(VM_OBSERVING, V_UID);
+        }
+    }
+    while ((v = nr_next())) {
         LOG(1000, ("TrickleReintegrate: checking %s\n", v->GetName()));
         if (v->Enter((VM_OBSERVING | VM_NDELAY), V_UID) == 0) {
             /* force a connectivity check? */

--- a/coda-src/venus/vol_reintegrate.cc
+++ b/coda-src/venus/vol_reintegrate.cc
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2018 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -811,8 +811,8 @@ void reintegrator::main(void)
             CHOKE("reintegrator::main: signalled but not dispatched!");
 
         /* Do the reintegration. */
-        if (u.u_vol && u.u_vol->IsReplicated())
-            ((repvol *)u.u_vol)->Reintegrate();
+        if (u.u_vol && u.u_vol->IsReadWrite())
+            ((reintvol *)u.u_vol)->Reintegrate();
 
         seq++;
         idle = 1;

--- a/coda-src/venus/vol_reintegrate.cc
+++ b/coda-src/venus/vol_reintegrate.cc
@@ -165,9 +165,9 @@ void reintvol::Reintegrate()
         code = IncReintegrate(thisTid);
 
         /* Log how many entries are left to reintegrate */
-        MarinerLog("reintegrate::%s, 0/%d\n", name, CML.count());
-        eprint("Reintegrate: %s, %d/%d records, result = %s", name, nrecs,
-               startedrecs, VenusRetStr(code));
+        MarinerLog("reintegrate::%s, 0/%d\n", name, startedrecs);
+        eprint("Reintegrate: %s, 0/%d records, result = %s", name, startedrecs,
+               VenusRetStr(code));
 
         /*
          * Keep going as long as we managed to reintegrate records without

--- a/coda-src/venus/vol_reintegrate.cc
+++ b/coda-src/venus/vol_reintegrate.cc
@@ -722,7 +722,7 @@ static const int ReintegratorPriority  = LWP_NORMAL_PRIORITY - 2;
 
 /* local-repair modification */
 class reintegrator : public vproc {
-    friend void Reintegrate(repvol *);
+    friend void Reintegrate(reintvol *);
 
     static olist freelist;
     olink handle;
@@ -746,7 +746,7 @@ olist reintegrator::freelist;
 /* This is the entry point for reintegration. */
 /* It finds a free reintegrator (or creates a new one), 
    sets up its context, and gives it a poke. */
-void Reintegrate(repvol *v)
+void Reintegrate(reintvol *v)
 {
     LOG(0, ("Reintegrate\n"));
     /* Get a free reintegrator. */

--- a/coda-src/venus/vol_vcb.cc
+++ b/coda-src/venus/vol_vcb.cc
@@ -367,6 +367,20 @@ RepExit:
 /* collate version stamp and callback status out parameters from servers */
 void reintvol::UpdateVCBInfo(RPC2_Integer VS, CallBackStatus CBStatus)
 {
+    if (LogLevel >= 100) {
+        fprintf(logFile, "reintvol::UpdateVCBInfo: vid %08x Current VVV:\n",
+                vid);
+        FPrintVV(logFile, &VVV);
+
+        fprintf(logFile,
+                "reintvol::UpdateVCBInfo: Version stamps returned: %d\n", VS);
+
+        fprintf(logFile,
+                "reintvol::UpdateVCBInfo: Callback status returned: %d\n",
+                CBStatus);
+        fflush(logFile);
+    }
+
     /* This is the single server version of CollateVCB */
     if (CBStatus == CallBackSet) {
         SetCallBack();
@@ -379,7 +393,7 @@ void reintvol::UpdateVCBInfo(RPC2_Integer VS, CallBackStatus CBStatus)
         ClearCallBack();
 
         /* check if any of the returned stamp is zero.
-               If so, server said stamp invalid. */
+            If so, server said stamp invalid. */
         if (VS == 0) {
             Recov_BeginTrans();
             RVMLIB_REC_OBJECT(VVV);

--- a/coda-src/venus/vol_vcb.cc
+++ b/coda-src/venus/vol_vcb.cc
@@ -95,7 +95,6 @@ int reintvol::GetVolAttr(uid_t uid)
     VOL_ASSERT(this, IsReachable());
 
     unsigned int i;
-    int code = 0;
 
     /* Acquire an Mgroup. */
     mgrpent *m = 0;

--- a/coda-src/venus/vol_vcb.cc
+++ b/coda-src/venus/vol_vcb.cc
@@ -343,18 +343,17 @@ int reintvol::GetVolAttr(uid_t uid)
                 }
 
                 CODA_ASSERT(v->IsReadWrite());
-                repvol *vp = (repvol *)v;
 
                 switch (VFlags[i]) {
                 case 1: /* OK, callback */
                     if (cbtemp == cbbreaks) {
                         LOG(1000, ("volent::GetVolAttr: vid 0x%x valid\n",
-                                   vp->GetVolumeId()));
-                        vp->SetCallBack();
+                                   GetVolumeId()));
+                        SetCallBack();
 
                         /* validate cached access rights for the caller */
                         struct dllist_head *p;
-                        list_for_each(p, vp->fso_list)
+                        list_for_each(p, fso_list)
                         {
                             fsobj *f =
                                 list_entry_plusplus(p, fsobj, vol_handle);
@@ -369,16 +368,16 @@ int reintvol::GetVolAttr(uid_t uid)
                 case 0: /* OK, no callback */
                     LOG(0, ("volent::GetVolAttr: vid 0x%x valid, no "
                             "callback\n",
-                            vp->GetVolumeId()));
-                    vp->ClearCallBack();
+                            GetVolumeId()));
+                    ClearCallBack();
                     break;
                 default: /* not OK */
                     LOG(1, ("volent::GetVolAttr: vid 0x%x invalid\n",
-                            vp->GetVolumeId()));
-                    vp->ClearCallBack();
+                            GetVolumeId()));
+                    ClearCallBack();
                     Recov_BeginTrans();
-                    RVMLIB_REC_OBJECT(vp->VVV);
-                    vp->VVV = NullVV;
+                    RVMLIB_REC_OBJECT(VVV);
+                    VVV = NullVV;
                     Recov_EndTrans(MAXFP);
                     break;
                 }

--- a/coda-src/venus/vol_vcb.cc
+++ b/coda-src/venus/vol_vcb.cc
@@ -86,7 +86,7 @@ int reintvol::GetVolAttr(uid_t uid)
     long cbtemp    = cbbreaks;
     mgrpent *m     = 0;
     unsigned int i = 0;
-    struct RPC2_common_params rpc_common;
+    struct MRPC_common_params rpc_common;
     struct in_addr ph_addr;
     int ret_code = 0;
     LOG(100, ("reintvol::GetVolAttr: %s, vid = 0x%x\n", name, vid));

--- a/coda-src/venus/vol_vcb.cc
+++ b/coda-src/venus/vol_vcb.cc
@@ -79,10 +79,10 @@ int vdb::CallBackBreak(Volid *volid)
  */
 int reintvol::GetVolAttr(uid_t uid)
 {
-    int code        = 0;
-    connent *c      = NULL;
+    int code   = 0;
+    connent *c = NULL;
     nonrepvol_iterator next;
-    repvol *repv = (repvol *)this;
+    repvol *repv   = (repvol *)this;
     long cbtemp    = cbbreaks;
     mgrpent *m     = 0;
     unsigned int i = 0;
@@ -119,10 +119,10 @@ int reintvol::GetVolAttr(uid_t uid)
 
     {
         /*
-	 * if we're fetching (as opposed to validating) volume state, 
-	 * we must first ensure all cached file state from this volume 
-	 * is valid (i.e., our cached state corresponds to the version 
-	 * information we will get).  If the file state can't be 
+	 * if we're fetching (as opposed to validating) volume state,
+	 * we must first ensure all cached file state from this volume
+	 * is valid (i.e., our cached state corresponds to the version
+	 * information we will get).  If the file state can't be
 	 * validated, we bail.
 	 */
         if (VV_Cmp(&VVV, &NullVV) == VV_EQ) {
@@ -216,7 +216,7 @@ int reintvol::GetVolAttr(uid_t uid)
 	     * demotion, it may appear to still have a callback when viewed
 	     * "externally" as we do here. This does not violate correctness,
 	     * because if an object is referenced in the volume the demotion
-	     * will be taken first.  
+	     * will be taken first.
 	     *
 	     * We do not bother checking the stamps for volumes not in the
 	     * hoarding state; when the transition is taken to the hoarding
@@ -487,9 +487,9 @@ void repvol::CollateVCB(mgrpent *m, RPC2_Integer *sbufs, CallBackStatus *cbufs)
  *
  * Error handling is simple: if one occurs, quit and propagate.
  * There's no volume synchronization because we've already
- * done it. 
- * 
- * complications: 
+ * done it.
+ *
+ * complications:
  * - this can't be called from fsdb::Get (a reasonable place)
  *   unless the target fid is known, because this routine calls
  *   fsdb::Get on potentially everything.
@@ -558,7 +558,7 @@ void reintvol::PackVS(int nstamps, RPC2_CountedBS *BS)
 int reintvol::CallBackBreak()
 {
     /*
-     * Track vcb's broken for this volume. Total vcb's broken is 
+     * Track vcb's broken for this volume. Total vcb's broken is
      * accumulated in vdb::CallbackBreak.
      */
 
@@ -588,13 +588,13 @@ void reintvol::SetCallBack()
 
 int reintvol::WantCallBack()
 {
-    /* 
-     * This is a policy module that decides if a volume 
+    /*
+     * This is a policy module that decides if a volume
      * callback is worth acquiring.  This is a naive policy,
      * with a minimal threshold for files.  One could use
      * CallBackClears as an approximation to the partition
      * rate (p), and CallbackBreaks as an approximation
-     * to the mutation rate (m). 
+     * to the mutation rate (m).
      */
     struct dllist_head *p;
     int count = 0;

--- a/coda-src/vice/codaproc.cc
+++ b/coda-src/vice/codaproc.cc
@@ -979,7 +979,7 @@ int SetRights(Vnode *vptr, char *name, int rights)
 {
     int Id;
     AL_AccessList *aCL = 0;
-    int aCLSize        = 0;
+    // int aCLSize        = 0;
 
     SLog(9, "Entering SetRights(%s %d)", name, rights);
     if (AL_NameToId(name, &Id) < 0) {
@@ -988,7 +988,7 @@ int SetRights(Vnode *vptr, char *name, int rights)
     }
     /* set the ACL */
     aCL     = VVnodeACL(vptr);
-    aCLSize = VAclSize(vptr);
+    // aCLSize = VAclSize(vptr);
 
     /* find the entry */
     for (int i = 0; i < aCL->PlusEntriesInUse; i++) {
@@ -1038,7 +1038,7 @@ int SetNRights(Vnode *vptr, char *name, int rights)
 {
     int Id;
     AL_AccessList *aCL = 0;
-    int aCLSize        = 0;
+    // int aCLSize        = 0;
     int p, m, t;
 
     SLog(9, "Entering SetNRights(%s %d)", name, rights);
@@ -1048,7 +1048,7 @@ int SetNRights(Vnode *vptr, char *name, int rights)
     }
     /* set the ACL */
     aCL     = VVnodeACL(vptr);
-    aCLSize = VAclSize(vptr);
+    // aCLSize = VAclSize(vptr);
 
     p = aCL->PlusEntriesInUse;
     m = aCL->MinusEntriesInUse;

--- a/coda-src/vice/codaproc.cc
+++ b/coda-src/vice/codaproc.cc
@@ -987,7 +987,7 @@ int SetRights(Vnode *vptr, char *name, int rights)
         return -1;
     }
     /* set the ACL */
-    aCL     = VVnodeACL(vptr);
+    aCL = VVnodeACL(vptr);
     // aCLSize = VAclSize(vptr);
 
     /* find the entry */
@@ -1047,7 +1047,7 @@ int SetNRights(Vnode *vptr, char *name, int rights)
         return -1;
     }
     /* set the ACL */
-    aCL     = VVnodeACL(vptr);
+    aCL = VVnodeACL(vptr);
     // aCLSize = VAclSize(vptr);
 
     p = aCL->PlusEntriesInUse;

--- a/coda-src/vice/srv.cc
+++ b/coda-src/vice/srv.cc
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2018 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under

--- a/coda-src/vice/srvproc.cc
+++ b/coda-src/vice/srvproc.cc
@@ -1033,6 +1033,7 @@ int ValidateParms(RPC2_Handle RPCid, ClientEntry **client, int *voltype,
     int errorCode = 0;
     VolumeId GroupVid;
     int count, pos;
+    int voltype_tmp;
 
     /* 1. Apply PiggyBacked COP2 operations. */
     if (PiggyBS && PiggyBS->SeqLen > 0) {
@@ -1054,15 +1055,18 @@ int ValidateParms(RPC2_Handle RPCid, ClientEntry **client, int *voltype,
 
     /* 3. Translate group to read/write volume id. */
     GroupVid  = *Vidp;
-    errorCode = XlateVid(Vidp, &count, &pos, voltype);
+    errorCode = XlateVid(Vidp, &count, &pos, &voltype_tmp);
 
-    if (*voltype & REPVOL) {
+    if (voltype_tmp & REPVOL) {
         SLog(10, "ValidateParms: %x --> %x", GroupVid, *Vidp);
-    } else if (*voltype & NONREPVOL) {
+    } else if (voltype_tmp & NONREPVOL) {
         SLog(10, "ValidateParms: using non-replicated vol --> %x", *Vidp);
     } else if (!errorCode) {
         SLog(10, "ValidateParms: using replica %x", *Vidp);
     }
+
+    if (voltype)
+        *voltype = voltype_tmp;
 
     if (Nservers)
         *Nservers = count;

--- a/coda-src/vicedep/srv.h
+++ b/coda-src/vicedep/srv.h
@@ -1,9 +1,9 @@
 /* BLURB lgpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2018 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -239,9 +239,9 @@ extern void COP2Update(Volume *, Vnode *, ViceVersionVector *);
 extern long InternalCOP2(RPC2_Handle, ViceStoreId *, ViceVersionVector *);
 extern void PollAndYield();
 extern int GetSubTree(ViceFid *, Volume *, dlist *);
-extern void GetMyVS(Volume *, RPC2_CountedBS *, RPC2_Integer *);
+extern void GetMyVS(Volume *, RPC2_CountedBS *, RPC2_Integer *, int voltype);
 extern void SetVSStatus(ClientEntry *, Volume *, RPC2_Integer *,
-                        CallBackStatus *);
+                        CallBackStatus *, int voltype);
 
 /* codaproc2.c */
 extern int LookupChild(Volume *, Vnode *, char *, ViceFid *);

--- a/coda-src/vol/vrdb.cc
+++ b/coda-src/vol/vrdb.cc
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2018 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -218,20 +218,20 @@ bool IsReplicated(VolumeId *vidp)
     return false;
 }
 
-int XlateVid(VolumeId *vidp, int *count, int *pos, bool *isReplicated)
+int XlateVid(VolumeId *vidp, int *count, int *pos, int *voltype)
 {
     if (!IsReplicated(vidp)) {
         if (count)
             *count = 1;
         if (pos)
             *pos = 0;
-        if (isReplicated)
-            *isReplicated = false;
+        if (voltype)
+            *voltype = NONREPVOL;
         return (1);
     }
 
-    if (isReplicated)
-        *isReplicated = true;
+    if (voltype)
+        *voltype = 0;
 
     vrent *vre = VRDB.find(*vidp);
     if (!vre)
@@ -240,6 +240,9 @@ int XlateVid(VolumeId *vidp, int *count, int *pos, bool *isReplicated)
     int ix = vre->index();
     if (ix == -1)
         return (0);
+
+    if (voltype)
+        *voltype = REPVOL;
 
     *vidp = vre->ServerVolnum[ix];
     if (count)

--- a/coda-src/vol/vrdb.h
+++ b/coda-src/vol/vrdb.h
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2018 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -101,7 +101,7 @@ public
 extern vrtab VRDB;
 extern void CheckVRDB();
 extern int DumpVRDB(int outfd);
-extern int XlateVid(VolumeId *, int * = NULL, int * = NULL, bool * = NULL);
+int XlateVid(VolumeId *, int * = NULL, int * = NULL, int *voltype = NULL);
 extern int ReverseXlateVid(VolumeId *, int * = NULL);
 
 #endif /* _VICE_VRDB_H_ */


### PR DESCRIPTION
This includes further changes for fully enabling non-replicated. The following issues were fixed;
* Volumes Callbacks weren't enabled for non-replicated volumes
* Non-replicated volumes weren't accessible when disconnected from server (even when fully cached)
* Shadow container files weren't being created for non-replicated volumes
* GetAttr/GetACL/SetAttr/SetACL where handling non-replicated volumes as volume replicas
* VDB wasn't calling AttachFidBindings/WriteDisconnect/ListCache for non-replicated volumes
* Vice wasn't capable of distinguishing between volume replica and non-replicated volume