### PR TITLE
Fix random crashing of venus when plan9server was enabled but being used

### DIFF
--- a/coda-src/venus/9pfs.cc
+++ b/coda-src/venus/9pfs.cc
@@ -466,6 +466,7 @@ static char *getusername(uid_t uid)
 }
 
 plan9server::plan9server(mariner *m)
+    : fids()
 {
     conn      = m;
     max_msize = P9_BUFSIZE;

--- a/coda-src/venus/mariner.cc
+++ b/coda-src/venus/mariner.cc
@@ -1,9 +1,9 @@
 /* BLURB gpl
 
                            Coda File System
-                              Release 6
+                              Release 7
 
-          Copyright (c) 1987-2018 Carnegie Mellon University
+          Copyright (c) 1987-2019 Carnegie Mellon University
                   Additional copyrights listed below
 
 This  code  is  distributed "AS IS" without warranty of any kind under
@@ -325,6 +325,7 @@ mariner::mariner(int afd)
     want_volstate = 0;
     uid           = ANYUSER_UID;
     fd            = afd;
+    p9srv         = NULL;
     memset(commbuf, 0, MWBUFSIZE);
 
     Lock_Init(&write_lock);


### PR DESCRIPTION
In k_Replace we check `m->p9srv != NULL` to call `m->9psrv->findmap_replace_cfid(fid_1, fid_2)`.

We never set `mariner::p9srv` to NULL during construction/init of mariner objects.