### PR TITLE
Fixed call to 'volutil' (removed leading space from argument)

### DIFF
--- a/coda-src/scripts/createvol_rep.in
+++ b/coda-src/scripts/createvol_rep.in
@@ -204,7 +204,7 @@ rm -f "/tmp/out.$$"
 # HACK, disable resolution on singly replicated volumes. The server should
 # really be doing this.
 if [ $NSERVERS -eq 1 ] ; then
-    volutil -h "$SERVERS" setlogparms "$volnum" reson 0
+    volutil -h $SERVERS setlogparms "$volnum" reson 0
 fi
 
 # Rebuild the VLDB


### PR DESCRIPTION
Due to line 152 the variable 'SERVERS' contains a leading space.
Since this variable is quoted when given as argument, the shell
preserves the space and 'volutil' gets confused because of the invalid
hostname.
Fixed this by removing the doublequotes.